### PR TITLE
[HTM-38] Add database connectivity for Tailormap API

### DIFF
--- a/.github/workflows/macos-maven.yml
+++ b/.github/workflows/macos-maven.yml
@@ -1,4 +1,4 @@
-name: Maven build
+name: MacOS Maven build
 
 env:
   MAVEN_OPTS: -Djava.awt.headless=true
@@ -8,8 +8,8 @@ on:
 
 jobs:
   build:
-    name: MacOS/Java 11
-    runs-on: macos-10.15
+    name: Build w/ Java 11
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -54,6 +54,7 @@ jobs:
           retention-days: 2
           path: target/site/
 
+
   site-deploy:
     name: Publish gh-pages
     runs-on: ubuntu-latest
@@ -77,6 +78,7 @@ jobs:
         with:
           branch: gh-pages
           folder: target/site
+
 
   deploy:
     name: Deploy artifacts
@@ -102,12 +104,9 @@ jobs:
           java-version: 11
           distribution: 'temurin'
 
-      #      - name: Log in to registry
-      #        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
       - name: Build and Push
         # no need to run any QC or tests
-        # note deploy will deploy both Maven artifact as well as docker image
+        # note deploy will deploy both Maven artifact as well as Docker image
         env:
           REPO_B3P_ACTOR: ${{ secrets.REPO_B3P_ACTOR }}
           REPO_B3P_TOKEN: ${{ secrets.REPO_B3P_TOKEN }}
@@ -168,10 +167,11 @@ jobs:
       - name: Try Created Docker image
         run: |
           docker run -d --name tailormap-api -h tailormap-api --network host ghcr.io/b3partners/tailormap-api:snapshot
-          sleep 10
+          sleep 60
           docker logs tailormap-api
           curl http://localhost:8080/api/actuator/health
           curl http://localhost:8080/api/version
+
 
   cleanup:
     name: Maven cache cleanup

--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -1,4 +1,4 @@
-name: Maven build
+name: Ubuntu Maven build
 
 env:
   MAVEN_OPTS: -Djava.awt.headless=true
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Ubuntu/Java 11
+    name: Build w/ Java 11
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -36,21 +36,11 @@ jobs:
           mvn -B -fae -e test
           mvn -B -fae -e verify
 
-      - name: Try Created Docker image
-        run: |
-          docker run --rm -d --name tailormap-api -h tailormap-api -p 8080:8080 ghcr.io/b3partners/tailormap-api:snapshot
-          sleep 10
-          curl http://localhost:8080/actuator/health
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
 
       - name: Build javadoc
         run: mvn javadoc:javadoc
-
-      # because unit test are now package private no javadoc for tests
-      # - name: Build test javadoc
-      #   run: mvn javadoc:test-javadoc
 
       - name: Build Maven site
         run: mvn site
@@ -89,7 +79,7 @@ jobs:
           folder: target/site
 
   deploy:
-    name: deploy artifacts
+    name: Deploy artifacts
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -125,6 +115,63 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mvn -B -V -fae -DskipTests -DskipITs -DskipQA=true -Pqa-skip clean deploy --settings .github/maven-settings.xml
+
+
+  docker-test:
+    name: Test docker image
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'pull_request' }}
+    env: # these defaults are also in the respective TM images
+      PG_PORT: 5432
+      DB_NAME: tailormap
+      DB_USER: tailormap
+      DB_PASS: tailormap
+
+    services:
+      postgres:
+        image: postgres:14.1-alpine
+        env:
+          POSTGRES_USER: ${{ env.DB_USER }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASS }}
+          POSTGRES_DB: ${{ env.DB_NAME }}
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 15s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'temurin'
+
+      - name: Build docker image
+        run: mvn -B -V -fae -DskipTests -DskipITs -DskipQA=true -Pqa-skip package
+
+      - name: Init database w/ Tailormap Admin
+        # use Tailormap Admin to initialize the PostgreSQL database schema
+        run: |
+          docker run -d --name tailormap-admin -h tailormap-admin --network host ghcr.io/b3partners/tailormap-admin:snapshot
+          sleep 60
+          docker logs tailormap-admin
+          docker stop tailormap-admin
+      - name: Try Created Docker image
+        run: |
+          docker run -d --name tailormap-api -h tailormap-api --network host ghcr.io/b3partners/tailormap-api:snapshot
+          sleep 10
+          docker logs tailormap-api
+          curl http://localhost:8080/api/actuator/health
+          curl http://localhost:8080/api/version
 
   cleanup:
     name: Maven cache cleanup

--- a/.github/workflows/windows-maven.yml
+++ b/.github/workflows/windows-maven.yml
@@ -1,4 +1,4 @@
-name: Maven build
+name: Windows Maven build
 
 env:
   MAVEN_OPTS: -Djava.awt.headless=true
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Windows/Java 11
+    name: Build w/ Java 11
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,21 +21,19 @@ LABEL org.opencontainers.image.authors="@mprins" \
       nl.b3p.image="Tailormap API" \
       nl.b3p.version=$TAILORMAP_API_VERSION
 
-
+# set-up timezone and local user
 RUN set -eux;ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
     && addgroup -S spring && adduser -S spring -G spring
 
 USER spring:spring
 
-WORKDIR /home
+WORKDIR /home/spring
 
 COPY ./target/tailormap-api.jar tailormap-api.jar
 
 EXPOSE 8080
-# see https://docs.spring.io/spring-boot/docs/2.5.6/actuator-api/htmlsingle/#health
-HEALTHCHECK --interval=25s --timeout=3s --retries=2 CMD wget --spider --header 'Accept: application/json' http://localhost:8080/api/actuator/health || exit 1
+# see https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#health
+HEALTHCHECK --interval=25s --timeout=3s --retries=2 CMD wget -nv --spider --tries=1 --no-verbose --header 'Accept: application/json' http://127.0.0.1:8080/api/actuator/health || exit 1
 
+# note that Spring Boot logs to the console, there is no logfile
 ENTRYPOINT ["java", "-jar", "tailormap-api.jar"]
-
-# TODO volume for logfiles
-# VOLUME [""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ ARG TAILORMAP_API_VERSION=0.1
 ARG TZ="Europe/Amsterdam"
 ARG DEBIAN_FRONTEND="noninteractive"
 
+ENV DB_URL=jdbc:postgresql:pgservice:/tm-config
+ENV DB_USER=test
+ENV DB_PASSWORD=test
+
+
 LABEL org.opencontainers.image.authors="@mprins" \
       description="Tailormap API service" \
       nl.b3p.vendor="B3Partners" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,14 @@
 #
 FROM eclipse-temurin:11.0.13_8-jre-alpine
 
-ARG TAILORMAP_API_VERSION=0.1
+ARG TAILORMAP_API_VERSION="0.1-SNAPSHOT"
 ARG TZ="Europe/Amsterdam"
 ARG DEBIAN_FRONTEND="noninteractive"
 
-ENV DB_URL=jdbc:postgresql:pgservice:/tm-config
-ENV DB_USER=test
-ENV DB_PASSWORD=test
+# defaults
+ENV SPRING_DATASOURCE_URL="jdbc:postgresql://127.0.0.1/tailormap"
+ENV DB_USER="tailormap"
+ENV DB_PASSWORD="tailormap"
 
 
 LABEL org.opencontainers.image.authors="@mprins" \
@@ -32,7 +33,7 @@ COPY ./target/tailormap-api.jar tailormap-api.jar
 
 EXPOSE 8080
 # see https://docs.spring.io/spring-boot/docs/2.5.6/actuator-api/htmlsingle/#health
-HEALTHCHECK --interval=25s --timeout=3s --retries=2 CMD wget --spider --header 'Accept: application/json' http://localhost:8080/actuator/health || exit 1
+HEALTHCHECK --interval=25s --timeout=3s --retries=2 CMD wget --spider --header 'Accept: application/json' http://localhost:8080/api/actuator/health || exit 1
 
 ENTRYPOINT ["java", "-jar", "tailormap-api.jar"]
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,16 @@ You can run this application in various ways:
 - using the runnable jar
 - running the docker image as a container
   ```shell
-    ￼docker run --rm -it --name tailormap-api -h tailormap-api -p 8080:8080 ghcr.io/b3partners/tailormap-api:snapshot
+  # using the defaults
+  docker run --rm -it --name tailormap-api -h tailormap-api --network host ghcr.io/b3partners/tailormap-api:snapshot
+  
+  # using a different database URL
+  docker run --rm -it --name tailormap-api -h tailormap-api -e "SPRING_DATASOURCE_URL=jdbc:postgresql://127.0.0.1:5433/tailormaps" --network host ghcr.io/b3partners/tailormap-api:snapshot
+  ￼
   ```
-  You can then point your browser at eg. `http://localhost:8080/version` or `http://localhost:8080/actuator/health`
+  You can then point your browser at eg. `http://localhost:8080/api/version` or `http://localhost:8080/api/actuator/health`
 
+Note that you need to have a configured database that at least has the tailormap schema; running the Tailormap Admin once should take care of that. 
 
 ## Releasing
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,10 +105,11 @@ SPDX-License-Identifier: MIT
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceVersion>${java.version}</project.build.sourceVersion>
     <project.build.targetVersion>${java.version}</project.build.targetVersion>
-    <project.build.outputTimestamp>2021-11-11T16:01:17Z</project.build.outputTimestamp>
+    <!--    <project.build.outputTimestamp>2021-11-11T16:01:17Z</project.build.outputTimestamp>-->
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <spring.boot.version>${project.parent.version}</spring.boot.version>
+    <org.tailormap.version>5.9.12-SNAPSHOT</org.tailormap.version>
     <maven.surefire.version>3.0.0-M5</maven.surefire.version>
     <test.junit-jupiter.version>5.8.2</test.junit-jupiter.version>
     <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
@@ -202,7 +203,7 @@ SPDX-License-Identifier: MIT
     <dependency>
       <groupId>org.tailormap</groupId>
       <artifactId>viewer-config-persistence</artifactId>
-      <version>5.9.11</version>
+      <version>${org.tailormap.version}</version>
       <exclusions>
         <exclusion>
           <!-- SLF4J is provided by SpringBoot through logback -->
@@ -210,6 +211,32 @@ SPDX-License-Identifier: MIT
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
+    <dependency>
+      <!-- this has "testdata.sql" that can be use to setup a HSQLDB test database -->
+      <groupId>org.tailormap</groupId>
+      <artifactId>viewer-config-persistence</artifactId>
+      <version>${org.tailormap.version}</version>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- SLF4J is provided by SpringBoot through logback -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <repositories>
@@ -235,7 +262,6 @@ SPDX-License-Identifier: MIT
       <resource>
         <directory>${basedir}/src/main/resources</directory>
         <excludes>
-          <exclude>**/application*.yml</exclude>
           <exclude>**/application*.properties</exclude>
           <exclude>**/index.html</exclude>
         </excludes>
@@ -284,6 +310,9 @@ SPDX-License-Identifier: MIT
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${spring.boot.version}</version>
+          <configuration>
+            <cleanCache>true</cleanCache>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
@@ -410,6 +439,8 @@ SPDX-License-Identifier: MIT
           <argLine>${surefireArgLine}</argLine>
           <systemPropertyVariables>
             <project.version>${project.version}</project.version>
+            <!-- TODO read this from property of yaml file -->
+            <api.version>v1</api.version>
           </systemPropertyVariables>
           <excludes>
             <exclude>**/*IntegrationTest.java</exclude>
@@ -429,6 +460,7 @@ SPDX-License-Identifier: MIT
           <systemPropertyVariables>
             <project.version>${project.version}</project.version>
           </systemPropertyVariables>
+          <useFile>false</useFile>
         </configuration>
         <executions>
           <execution>
@@ -464,6 +496,45 @@ SPDX-License-Identifier: MIT
               <goal>jar</goal>
             </goals>
             <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack-test-resources</id>
+            <!-- extract testdata.sql from viewer-config-persistence:tests to import.sql -->
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>process-test-classes</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.tailormap</groupId>
+                  <artifactId>viewer-config-persistence</artifactId>
+                  <type>test-jar</type>
+                  <classifier>tests</classifier>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
+                  <includes>**/testdata.sql</includes>
+                  <fileMappers>
+                    <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper></org.codehaus.plexus.components.io.filemappers.FlattenFileMapper>
+                    <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                      <pattern>testdata.sql</pattern>
+                      <replacement>import.sql</replacement>
+                    </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                  </fileMappers>
+                </artifactItem>
+              </artifactItems>
+              <includes>**/*.java</includes>
+              <excludes>**/*.properties</excludes>
+              <outputDirectory>${project.build.directory}/wars</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -659,7 +730,7 @@ SPDX-License-Identifier: MIT
                     <exclude>org.springframework.boot:spring-boot-starter-test</exclude>
                     <!--
                     TODO this should be fixed; either by importing or exluding the transitive dependencies
-                   org.tailormap:viewer-config-persistence:jar:5.9.11:compile has transitive dependencies:
+                   org.tailormap:viewer-config-persistence:jar:5.9.12-SNAPSHOT:compile has transitive dependencies:
                       org.apache.commons:commons-lang3:jar:3.12.0:compile
                       commons-beanutils:commons-beanutils:jar:1.9.4:compile
                          commons-logging:commons-logging:jar:1.2:compile

--- a/pom.xml
+++ b/pom.xml
@@ -162,19 +162,63 @@ SPDX-License-Identifier: MIT
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!--
+          this (broken!) transitive dependency from org.skyscreamer:jsonassert:jar:1.5.0:test conflicts
+          with org.json.json from org.tailormap:viewer-config-persistence
+          -->
+          <groupId>com.vaadin.external.google</groupId>
+          <artifactId>android-json</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <!-- provides @SuppressModernizer that can be used on method to suppress the Modernizer plugin -->
       <groupId>org.gaul</groupId>
       <artifactId>modernizer-maven-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.3.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.tailormap</groupId>
+      <artifactId>viewer-config-persistence</artifactId>
+      <version>5.9.11</version>
+      <exclusions>
+        <exclusion>
+          <!-- SLF4J is provided by SpringBoot through logback -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
+  <repositories>
+    <repository>
+      <id>B3Partners</id>
+      <name>Releases hosted by B3Partners</name>
+      <url>https://repo.b3p.nl/nexus/repository/public/</url>
+    </repository>
+  </repositories>
   <build>
     <defaultGoal>install</defaultGoal>
     <!-- no version number on jar makes building docker image easier -->
@@ -184,7 +228,7 @@ SPDX-License-Identifier: MIT
         <filtering>true</filtering>
         <directory>${basedir}/src/main/resources</directory>
         <includes>
-          <include>**/application*.yml</include>
+          <include>**/index.html</include>
           <include>**/application*.properties</include>
         </includes>
       </resource>
@@ -193,6 +237,7 @@ SPDX-License-Identifier: MIT
         <excludes>
           <exclude>**/application*.yml</exclude>
           <exclude>**/application*.properties</exclude>
+          <exclude>**/index.html</exclude>
         </excludes>
       </resource>
     </resources>
@@ -609,8 +654,23 @@ SPDX-License-Identifier: MIT
                 <banTransitiveDependencies>
                   <excludes>
                     <exclude>org.springframework.boot:spring-boot-starter-web</exclude>
+                    <exclude>org.springframework.boot:spring-boot-starter-data-jpa</exclude>
                     <exclude>org.springframework.boot:spring-boot-starter-actuator</exclude>
                     <exclude>org.springframework.boot:spring-boot-starter-test</exclude>
+                    <!--
+                    TODO this should be fixed; either by importing or exluding the transitive dependencies
+                   org.tailormap:viewer-config-persistence:jar:5.9.11:compile has transitive dependencies:
+                      org.apache.commons:commons-lang3:jar:3.12.0:compile
+                      commons-beanutils:commons-beanutils:jar:1.9.4:compile
+                         commons-logging:commons-logging:jar:1.2:compile
+                         commons-collections:commons-collections:jar:3.2.2:compile
+                      commons-io:commons-io:jar:2.11.0:compile
+                      org.json:json:jar:20210307:compile
+                      org.hibernate:hibernate-entitymanager:jar:5.6.1.Final:compile
+                         javax.persistence:javax.persistence-api:jar:2.2:compile
+                         org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:jar:1.1.1.Final:compile
+                    -->
+                    <exclude>org.tailormap:viewer-config-persistence</exclude>
                   </excludes>
                 </banTransitiveDependencies>
               </rules>

--- a/src/main/java/nl/b3p/tailormap/api/JPAConfiguration.java
+++ b/src/main/java/nl/b3p/tailormap/api/JPAConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import java.util.Properties;
+
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+
+@Configuration
+@EnableJpaRepositories(basePackages = {"nl.b3p.tailormap.api.repository"})
+@EnableTransactionManagement
+public class JPAConfiguration {
+    @Autowired private Environment env;
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+        final LocalContainerEntityManagerFactoryBean em =
+                new LocalContainerEntityManagerFactoryBean();
+        em.setPackagesToScan("nl.tailormap.viewer.config");
+        em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+        em.setJpaProperties(additionalProperties());
+        // for test
+        // em.setPersistenceUnitName("viewer-config-hsqldb");
+        em.setPersistenceUnitName("viewer-config-postgresql");
+        em.setDataSource(dataSource());
+
+        return em;
+    }
+
+    /**
+     * This is to override the config of the provided persistence module.
+     *
+     * @return configured datasource
+     */
+    @Bean
+    public DataSource dataSource() {
+        final DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setUrl(env.getProperty("spring.datasource.url"));
+        dataSource.setDriverClassName(env.getProperty("spring.datasource.driver-class-name"));
+        dataSource.setUsername(env.getProperty("spring.datasource.username"));
+        dataSource.setPassword(env.getProperty("spring.datasource.password"));
+
+        return dataSource;
+    }
+
+    @Bean
+    JpaTransactionManager transactionManager(final EntityManagerFactory entityManagerFactory) {
+        final JpaTransactionManager transactionManager = new JpaTransactionManager();
+        transactionManager.setEntityManagerFactory(entityManagerFactory);
+
+        return transactionManager;
+    }
+
+    @Bean
+    public PersistenceExceptionTranslationPostProcessor exceptionTranslation() {
+        return new PersistenceExceptionTranslationPostProcessor();
+    }
+
+    final Properties additionalProperties() {
+        final Properties hibernateProperties = new Properties();
+        //    hibernateProperties.setProperty(
+        //        "hibernate.hbm2ddl.auto", env.getProperty("spring.jpa.hibernate.ddl-auto", ""));
+        hibernateProperties.setProperty(
+                "hibernate.show_sql", env.getProperty("spring.jpa.show-sql", "false"));
+
+        return hibernateProperties;
+    }
+}

--- a/src/main/java/nl/b3p/tailormap/api/controller/AppController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/AppController.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@CrossOrigin
+@RequestMapping(path = "/app")
+public class AppController {
+
+    @Value("${tailormap-api.api_version}")
+    private String apiVersion;
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public String get(
+            @RequestParam(required = false) Integer appid,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String version) {
+
+        // TODO implement, for now just echo
+        return "{\"id\": "
+                + appid
+                + ","
+                + "\"api_version\": \""
+                + apiVersion
+                + "\","
+                + "\"name\": \""
+                + name
+                + "\","
+                + "\"version\": \""
+                + version
+                + "\","
+                + "\"title\": \"This is could be a cool mapping app\","
+                + "\"lang\": \"nl_NL\"}";
+    }
+}

--- a/src/main/java/nl/b3p/tailormap/api/controller/AppController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/AppController.java
@@ -5,6 +5,8 @@
  */
 package nl.b3p.tailormap.api.controller;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -14,35 +16,50 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 @CrossOrigin
 @RequestMapping(path = "/app")
 public class AppController {
+    private final Log logger = LogFactory.getLog(getClass());
 
     @Value("${tailormap-api.api_version}")
     private String apiVersion;
 
+    /**
+     * Produce version information.
+     *
+     * @param appid the unique identifier of an app
+     * @param name the name of an app
+     * @param version the version of an app
+     * @return the basic information needed to create an app in the frontend
+     * @since 0.1
+     */
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public String get(
+    public Map<String, Object> get(
             @RequestParam(required = false) Integer appid,
             @RequestParam(required = false) String name,
             @RequestParam(required = false) String version) {
 
+        logger.trace("got: " + appid + ", name: " + name + ", version: " + version);
+
         // TODO implement, for now just echo
-        return "{\"id\": "
-                + appid
-                + ","
-                + "\"api_version\": \""
-                + apiVersion
-                + "\","
-                + "\"name\": \""
-                + name
-                + "\","
-                + "\"version\": \""
-                + version
-                + "\","
-                + "\"title\": \"This is could be a cool mapping app\","
-                + "\"lang\": \"nl_NL\"}";
+        return Map.of(
+                "id",
+                appid,
+                "name",
+                name,
+                "api_version",
+                this.apiVersion,
+                "version",
+                version,
+                "title",
+                "This is could be a cool mapping app",
+                "lang",
+                "nl_NL"
+                // Note you can only have 10 K/V pairs in this Map.of(...)
+                );
     }
 }

--- a/src/main/java/nl/b3p/tailormap/api/controller/VersionController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/VersionController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 /**
  * Provides version information of backend, API and config database.
  *
@@ -25,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class VersionController {
     @Autowired private MetadataRepository metadataRepository;
 
-    // Maven 'process-resources' takes care of updating these in the application.properties
+    // Maven 'process-resources' takes care of updating these tokens in the application.properties
     @Value("${tailormap-api.version}")
     private String version;
 
@@ -38,12 +40,16 @@ public class VersionController {
      * @return api version
      */
     @GetMapping(path = "/version", produces = MediaType.APPLICATION_JSON_VALUE)
-    public String getVersion() {
+    public Map<String, String> getVersion() {
         final Metadata m = metadataRepository.findByConfigKey(Metadata.DATABASE_VERSION_KEY);
         final String dbVersion = ((null != m) ? m.getConfigValue() : "-1");
 
-        return String.format(
-                "{\"version\":\"%s\", \"databaseversion\":\"%s\", \"api_version\":\"%s\"}",
-                this.version, dbVersion, this.apiVersion);
+        return Map.of(
+                "version",
+                this.version,
+                "databaseversion",
+                dbVersion,
+                "api_version",
+                this.apiVersion);
     }
 }

--- a/src/main/java/nl/b3p/tailormap/api/controller/VersionController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/VersionController.java
@@ -5,25 +5,45 @@
  */
 package nl.b3p.tailormap.api.controller;
 
+import nl.b3p.tailormap.api.repository.MetadataRepository;
+import nl.tailormap.viewer.config.metadata.Metadata;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Provides version information. */
+/**
+ * Provides version information of backend, API and config database.
+ *
+ * @since 0.1
+ */
 @RestController
+@CrossOrigin
 public class VersionController {
+    @Autowired private MetadataRepository metadataRepository;
 
-    // the maven build takes care of updating this in the application.properties
+    // Maven 'process-resources' takes care of updating these in the application.properties
     @Value("${tailormap-api.version}")
     private String version;
+
+    @Value("${tailormap-api.api_version}")
+    private String apiVersion;
 
     /**
      * get API version.
      *
      * @return api version
      */
-    @GetMapping(path = "/version")
+    @GetMapping(path = "/version", produces = MediaType.APPLICATION_JSON_VALUE)
     public String getVersion() {
-        return this.version;
+        final Metadata m = metadataRepository.findByConfigKey(Metadata.DATABASE_VERSION_KEY);
+        final String dbVersion = ((null != m) ? m.getConfigValue() : "-1");
+
+        return String.format(
+                "{\"version\":\"%s\", \"databaseversion\":\"%s\", \"api_version\":\"%s\"}",
+                this.version, dbVersion, this.apiVersion);
     }
 }

--- a/src/main/java/nl/b3p/tailormap/api/repository/MetadataRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/MetadataRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.repository;
+
+import nl.tailormap.viewer.config.metadata.Metadata;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MetadataRepository extends JpaRepository<Metadata, Long> {
+
+    /**
+     * Find a metedata value using a known key such as {@link Metadata#DATABASE_VERSION_KEY} or
+     * {@link Metadata#DEFAULT_APPLICATION}.
+     *
+     * @param configKey known key
+     * @return the found value or {@code null}
+     */
+    Metadata findByConfigKey(String configKey);
+}

--- a/src/main/java/nl/b3p/tailormap/api/repository/MetadataRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/MetadataRepository.java
@@ -8,9 +8,12 @@ package nl.b3p.tailormap.api.repository;
 import nl.tailormap.viewer.config.metadata.Metadata;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+/**
+ * Easy to use methods to access {@link Metadata}.
+ *
+ * @since 0.1
+ */
 public interface MetadataRepository extends JpaRepository<Metadata, Long> {
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,23 @@
+# product version
 tailormap-api.version=@project.version@
+# TODO the api_version should be tokenized and retrieved from the tailormap-api.yaml
+tailormap-api.api_version=v1
+# base url
+# TODO the api_version should be tokenized and retrieved from the tailormap-api.yaml
+server.servlet.context-path=/api
+
+# database
+spring.datasource.url=jdbc:postgresql://127.0.0.1/tailormap
+spring.datasource.username=tailormap
+spring.datasource.password=tailormap
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.pool-size=30
+
+spring.jpa.show-sql=true
+
+# we don't need JMX
+spring.jmx.enabled=false
+
+logging.level.org.springframework.boot.autoconfigure=INFO
+logging.level.nl.tailormap.api=TRACE
+logging.level.org.hibernate=INFO

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,5 +19,5 @@ spring.jpa.show-sql=true
 spring.jmx.enabled=false
 
 logging.level.org.springframework.boot.autoconfigure=INFO
-logging.level.nl.tailormap.api=TRACE
 logging.level.org.hibernate=INFO
+logging.level.nl.b3p.tailormap.api=TRACE

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>@project.name@</title>
+</head>
+<body>
+<h1>@project.name@</h1>
+<p>@project.description@</p>
+<!--<p>Service definition: <a href="tailormap-api.yaml">tailormap-api.yaml</a></p>-->
+</body>
+</html>

--- a/src/main/resources/tailormap-api.yaml
+++ b/src/main/resources/tailormap-api.yaml
@@ -23,7 +23,7 @@ info:
 
 servers:
   - description: 'development server'
-    url: 'http://localhost:{port}/tailormap-api/{basePath}/'
+    url: 'http://localhost:{port}/api/'
     variables:
       port:
         enum:
@@ -32,8 +32,6 @@ servers:
           - '8443'
         default: '8080'
         description: 'port number'
-      basePath:
-        default: 'v1'
 
 components:
   schemas:
@@ -124,11 +122,24 @@ components:
           required: false
 
 paths:
+  /version:
+    summary: 'Provides version information of the backend'
+    get:
+      responses:
+        '200':
+          description: 'OK'
+          content:
+            application/json:
+              example:
+                version: '0.1-SNAPSHOT'
+                databaseversion: '46'
+                api_version: 'v1'
+
   /app/:
     summary: '
     Use this endpoint to get the id of the requested or default application.
     Either call this with `name` and optional `version` or `appid` alone.
-    Will return general setup information such as name, appid, language, but not map specific infrmation
+    Will return general setup information such as name, appid, language, but not map specific information
     '
     get:
       parameters:
@@ -160,6 +171,7 @@ paths:
                 id: 7
                 api_version: 'v1'
                 name: 'cool app'
+                version: '2'
                 title: 'This is a cool mapping app'
                 lang: 'nl_NL'
               schema:

--- a/src/test/java/nl/b3p/tailormap/api/HSQLDBTestProfileJPAConfiguration.java
+++ b/src/test/java/nl/b3p/tailormap/api/HSQLDBTestProfileJPAConfiguration.java
@@ -5,14 +5,14 @@
  */
 package nl.b3p.tailormap.api;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
-import org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.orm.jpa.JpaTransactionManager;
@@ -25,80 +25,63 @@ import java.util.Properties;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-/**
- * JPA configuration beans.
- *
- * @since 0.1
- */
 @Configuration
 @EnableJpaRepositories(basePackages = {"nl.b3p.tailormap.api.repository"})
-@EntityScan(
-        basePackages = {
-            "nl.tailormap.viewer.config",
-            "nl.tailormap.viewer.config.app",
-            "nl.tailormap.viewer.config.metadata",
-            "nl.tailormap.viewer.config.security",
-            "nl.tailormap.viewer.config.services"
-        })
 @EnableTransactionManagement
-public class JPAConfiguration {
+@Profile("test")
+public class HSQLDBTestProfileJPAConfiguration {
+    private static final Log LOG = LogFactory.getLog(HSQLDBTestProfileJPAConfiguration.class);
+
     @Autowired private Environment env;
 
-    private final Log logger = LogFactory.getLog(getClass());
-
     @Bean
+    @Profile("test")
     public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
         final LocalContainerEntityManagerFactoryBean em =
                 new LocalContainerEntityManagerFactoryBean();
-
+        em.setPackagesToScan("nl.tailormap.viewer.config");
         em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
         em.setJpaProperties(additionalProperties());
-        em.setPersistenceUnitName("viewer-config-postgresql");
+        em.setPersistenceUnitName("viewer-config-hsqldb");
         em.setDataSource(dataSource());
 
         return em;
     }
 
-    /**
-     * This is to override the config of the provided persistence module.
-     *
-     * @return configured datasource
-     */
     @Bean
+    @Profile("test")
     public DataSource dataSource() {
         final DriverManagerDataSource dataSource = new DriverManagerDataSource();
-        dataSource.setUrl(env.getProperty("spring.datasource.url"));
-        dataSource.setDriverClassName(env.getProperty("spring.datasource.driver-class-name"));
-        dataSource.setUsername(env.getProperty("spring.datasource.username"));
-        dataSource.setPassword(env.getProperty("spring.datasource.password"));
 
-        logger.debug(
-                "using database: "
-                        + env.getProperty("spring.datasource.url")
-                        + " with driver: "
-                        + env.getProperty("spring.datasource.driver-class-name"));
+        String dbUrl = "jdbc:hsqldb:file:./target/unittest-hsqldb-TESTNAMETOKEN/db;shutdown=true";
+        if (null != env.getProperty("spring.datasource.url")) {
+            dbUrl = env.getProperty("spring.datasource.url");
+        }
+        dbUrl = dbUrl.replace("TESTNAMETOKEN", RandomStringUtils.randomAlphabetic(8));
+        dataSource.setUrl(dbUrl);
+        LOG.debug("Using test datasource url: " + dataSource.getUrl());
+        dataSource.setDriverClassName("org.hsqldb.jdbcDriver");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+
         return dataSource;
     }
 
     @Bean
+    @Profile("test")
     JpaTransactionManager transactionManager(final EntityManagerFactory entityManagerFactory) {
         final JpaTransactionManager transactionManager = new JpaTransactionManager();
         transactionManager.setEntityManagerFactory(entityManagerFactory);
-
         return transactionManager;
-    }
-
-    @Bean
-    public PersistenceExceptionTranslationPostProcessor exceptionTranslation() {
-        return new PersistenceExceptionTranslationPostProcessor();
     }
 
     final Properties additionalProperties() {
         final Properties hibernateProperties = new Properties();
-        //    hibernateProperties.setProperty(
-        //        "hibernate.hbm2ddl.auto", env.getProperty("spring.jpa.hibernate.ddl-auto", ""));
+
         hibernateProperties.setProperty(
-                "hibernate.show_sql", env.getProperty("spring.jpa.show-sql", "false"));
+                "hibernate.hbm2ddl.auto", env.getProperty("spring.jpa.hibernate.ddl-auto"));
+        hibernateProperties.setProperty(
+                "hibernate.show_sql", env.getProperty("spring.jpa.show-sql", "true"));
 
         return hibernateProperties;
     }

--- a/src/test/java/nl/b3p/tailormap/api/TailormapApiApplicationTests.java
+++ b/src/test/java/nl/b3p/tailormap/api/TailormapApiApplicationTests.java
@@ -5,12 +5,9 @@
  */
 package nl.b3p.tailormap.api;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import nl.b3p.tailormap.api.controller.VersionController;
+import nl.b3p.tailormap.api.repository.MetadataRepository;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 /**
@@ -18,12 +15,12 @@ import org.springframework.boot.test.context.SpringBootTest;
  *
  * @since 0.1
  */
-@SpringBootTest
+@SpringBootTest(classes = {HSQLDBTestProfileJPAConfiguration.class, MetadataRepository.class})
 class TailormapApiApplicationTests {
-    @Autowired private VersionController vController;
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void contextLoads() {
-        assertNotNull(vController, "vController should be initilialized");
+        /* empty by design */
     }
 }

--- a/src/test/java/nl/b3p/tailormap/api/controller/VersionControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/VersionControllerIntegrationTest.java
@@ -9,17 +9,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import nl.b3p.tailormap.api.HSQLDBTestProfileJPAConfiguration;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-import java.io.IOException;
+import java.util.Map;
 
-@SpringBootTest
+/** Testcases for {@link VersionController}. */
+@SpringBootTest(classes = {HSQLDBTestProfileJPAConfiguration.class, VersionController.class})
+@ActiveProfiles("test")
 class VersionControllerIntegrationTest {
     private static String projectVersion;
-    @Autowired VersionController versionController;
+    private static String apiVersion;
+    @Autowired private VersionController versionController;
 
     @BeforeAll
     static void getVersionFromPom() {
@@ -28,16 +34,25 @@ class VersionControllerIntegrationTest {
         assumeFalse(
                 null == projectVersion,
                 "Project version unknown, should be set in system environment");
+        apiVersion = System.getProperty("api.version");
+        assumeFalse(null == apiVersion, "API version unknown, should be set in system environment");
     }
 
     @Test
-    void testGetVersion() throws IOException {
-        assertNotNull(versionController, "versionController can not be `null` if SpringBoot works");
+    void testGetVersion() {
+        assertNotNull(
+                versionController, "versionController can not be `null` if Spring Boot works");
         assertNotNull(versionController.getVersion(), "Version info not found");
 
-        assertEquals(
-                "{\"version\":\"0.1-SNAPSHOT\", \"databaseversion\":\"46\", \"api_version\":\"v1\"}",
-                versionController.getVersion(),
-                "Unexpected json response.");
+        Map<String, String> expected =
+                Map.of(
+                        "version",
+                        projectVersion,
+                        "databaseversion",
+                        "46",
+                        "api_version",
+                        apiVersion);
+
+        assertEquals(expected, versionController.getVersion(), "Unexpected version response.");
     }
 }

--- a/src/test/java/nl/b3p/tailormap/api/controller/VersionControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/VersionControllerIntegrationTest.java
@@ -16,9 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.io.IOException;
 
-// this test could just as well be a (unit)"Test" instead of an (i-test)"IntegrationTest", but we
-// wanted
-// to have an integration test to check if that works from Maven.
 @SpringBootTest
 class VersionControllerIntegrationTest {
     private static String projectVersion;
@@ -36,7 +33,11 @@ class VersionControllerIntegrationTest {
     @Test
     void testGetVersion() throws IOException {
         assertNotNull(versionController, "versionController can not be `null` if SpringBoot works");
-        assertNotNull(versionController.getVersion(), "Project version not found");
-        assertEquals(projectVersion, versionController.getVersion(), "Project version incorrect");
+        assertNotNull(versionController.getVersion(), "Version info not found");
+
+        assertEquals(
+                "{\"version\":\"0.1-SNAPSHOT\", \"databaseversion\":\"46\", \"api_version\":\"v1\"}",
+                versionController.getVersion(),
+                "Unexpected json response.");
     }
 }

--- a/src/test/java/nl/b3p/tailormap/api/repository/MetadataRepositoryIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/repository/MetadataRepositoryIntegrationTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import nl.tailormap.viewer.config.metadata.Metadata;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MetadataRepositoryIntegrationTest {
+
+    @Autowired private MetadataRepository metadataRepository;
+
+    @Test
+    void it_should_findByConfigKeyDefaultApplication() {
+        final Metadata m = metadataRepository.findByConfigKey(Metadata.DEFAULT_APPLICATION);
+        assertNotNull(m, "we should have found something");
+        assertEquals("1", m.getConfigValue(), "default application is not 1");
+    }
+
+    @Test
+    void it_should_findByConfigKeyDatabaseVersion() {
+        final Metadata m = metadataRepository.findByConfigKey(Metadata.DATABASE_VERSION_KEY);
+        assertNotNull(m, "we should have found something");
+        assertEquals("46", m.getConfigValue(), "version is not 46");
+    }
+}

--- a/src/test/java/nl/b3p/tailormap/api/repository/MetadataRepositoryIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/repository/MetadataRepositoryIntegrationTest.java
@@ -8,13 +8,20 @@ package nl.b3p.tailormap.api.repository;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import nl.b3p.tailormap.api.HSQLDBTestProfileJPAConfiguration;
 import nl.tailormap.viewer.config.metadata.Metadata;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@SpringBootTest
+/** Testcases for {@link MetadataRepository}. */
+@ActiveProfiles("test")
+@SpringBootTest(classes = {HSQLDBTestProfileJPAConfiguration.class, Metadata.class})
+@ExtendWith(SpringExtension.class)
 class MetadataRepositoryIntegrationTest {
 
     @Autowired private MetadataRepository metadataRepository;

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,27 @@
+# product version
+tailormap-api.version=@project.version@
+# TODO the api_version should be tokenized and retrieved from the tailormap-api.yaml
+tailormap-api.api_version=v1
+# base url
+# TODO the api_version should be tokenized and retrieved from the tailormap-api.yaml
+server.servlet.context-path=/api
+
+# in memory hsqldb (faster, but not possible to inspect database)
+# spring.datasource.url=jdbc:hsqldb:mem:unittest-hsqldb-TESTNAMETOKEN/db;DB_CLOSE_DELAY=-1
+# on disk hsqldb
+spring.datasource.url=jdbc:hsqldb:file:./target/unittest-hsqldb-TESTNAMETOKEN/db;shutdown=true
+spring.sql.init.mode=always
+spring.jpa.generate-ddl=true
+# wait for hibernate to create database
+spring.jpa.defer-datasource-initialization=true
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.datasource.driver-class-name=org.hsqldb.jdbcDriver
+
+
+spring.jpa.show-sql=false
+
+logging.level.org.springframework.boot.autoconfigure=INFO
+logging.level.org.hibernate=INFO
+logging.level.nl.b3p.tailormap.api=TRACE
+
+spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
Uses the original `org.tailormap:viewer-config-persistence` module for now and only for a preconfigured PostgreSQL config database.


resolves HTM-38