### PR TITLE
Optimize JPA tests by not initializing the whole application

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/repository/MetadataRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/MetadataRepository.java
@@ -8,6 +8,7 @@ package nl.b3p.tailormap.api.repository;
 import nl.tailormap.viewer.config.metadata.Metadata;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Easy to use methods to access {@link Metadata}.
@@ -17,11 +18,20 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MetadataRepository extends JpaRepository<Metadata, Long> {
 
     /**
-     * Find a metedata value using a known key such as {@link Metadata#DATABASE_VERSION_KEY} or
+     * Find a metadata value using a known key such as {@link Metadata#DATABASE_VERSION_KEY} or
      * {@link Metadata#DEFAULT_APPLICATION}.
      *
      * @param configKey known key
      * @return the found value or {@code null}
      */
     Metadata findByConfigKey(String configKey);
+
+    /**
+     * Delete a value from the metadata using a known key such as {@link
+     * Metadata#DEFAULT_APPLICATION}.
+     *
+     * @param configKey known key
+     */
+    @Transactional
+    void deleteMetadataByConfigKey(String configKey);
 }

--- a/src/test/java/nl/b3p/tailormap/api/repository/ApplicationRepositoryTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/repository/ApplicationRepositoryTest.java
@@ -11,23 +11,32 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import nl.b3p.tailormap.api.HSQLDBTestProfileJPAConfiguration;
 import nl.tailormap.viewer.config.app.Application;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 
 /** Testcases for {@link ApplicationRepository}. */
 @ActiveProfiles("test")
-@SpringBootTest(classes = {HSQLDBTestProfileJPAConfiguration.class, Application.class})
-@ExtendWith(SpringExtension.class)
-class ApplicationRepositoryIntegrationTest {
+@DataJpaTest(showSql = false)
+@AutoConfigureTestDatabase
+@EnableJpaRepositories(basePackages = {"nl.b3p.tailormap.api.repository"})
+@EntityScan(
+        basePackages = {
+            "nl.tailormap.viewer.config",
+            "nl.tailormap.viewer.config.app",
+            "nl.tailormap.viewer.config.metadata",
+            "nl.tailormap.viewer.config.security",
+            "nl.tailormap.viewer.config.services"
+        })
+class ApplicationRepositoryTest {
     @Autowired private ApplicationRepository applicationRepository;
 
     @Test

--- a/src/test/java/nl/b3p/tailormap/api/repository/MetadataRepositoryTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/repository/MetadataRepositoryTest.java
@@ -7,22 +7,32 @@ package nl.b3p.tailormap.api.repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import nl.b3p.tailormap.api.HSQLDBTestProfileJPAConfiguration;
 import nl.tailormap.viewer.config.metadata.Metadata;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /** Testcases for {@link MetadataRepository}. */
 @ActiveProfiles("test")
-@SpringBootTest(classes = {HSQLDBTestProfileJPAConfiguration.class, Metadata.class})
-@ExtendWith(SpringExtension.class)
-class MetadataRepositoryIntegrationTest {
+@DataJpaTest(showSql = false)
+@AutoConfigureTestDatabase
+@EnableJpaRepositories(basePackages = {"nl.b3p.tailormap.api.repository"})
+@EntityScan(
+        basePackages = {
+            "nl.tailormap.viewer.config",
+            "nl.tailormap.viewer.config.app",
+            "nl.tailormap.viewer.config.metadata",
+            "nl.tailormap.viewer.config.security",
+            "nl.tailormap.viewer.config.services"
+        })
+class MetadataRepositoryTest {
 
     @Autowired private MetadataRepository metadataRepository;
 
@@ -38,5 +48,12 @@ class MetadataRepositoryIntegrationTest {
         final Metadata m = metadataRepository.findByConfigKey(Metadata.DATABASE_VERSION_KEY);
         assertNotNull(m, "we should have found something");
         assertEquals("46", m.getConfigValue(), "version is not 46");
+    }
+
+    @Test
+    void it_should_not_find_value_after_deleting_key() {
+        metadataRepository.deleteMetadataByConfigKey(Metadata.DEFAULT_APPLICATION);
+        final Metadata m = metadataRepository.findByConfigKey(Metadata.DEFAULT_APPLICATION);
+        assertNull(m, "we should not have found anything");
     }
 }


### PR DESCRIPTION
It's not necessary to start the whole Spring Boot application for JPA tests, we just need an initialised database.