### PR TITLE
Return proper HTTP status on configuration error

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/controller/AppController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/AppController.java
@@ -29,9 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -95,8 +93,7 @@ public class AppController {
                         + version);
 
         if (null != appid) {
-            Optional<Application> a = applicationRepository.findById(appid);
-            this.application = a.isPresent() ? a.get() : null;
+            this.application = applicationRepository.findById(appid).orElse(null);
         } else {
             this.application = findApplication(name, version);
         }
@@ -141,9 +138,11 @@ public class AppController {
             if (null != version) {
                 application = applicationRepository.findByNameAndVersion(name, version);
             } else {
-                List<Application> applications = applicationRepository.findByName(name);
-                Optional<Application> a = applications.stream().sorted().findFirst();
-                application = a.isPresent() ? a.get() : null;
+                application =
+                        applicationRepository.findByName(name).stream()
+                                .sorted()
+                                .findFirst()
+                                .orElse(null);
             }
 
             if (null == application) {

--- a/src/main/java/nl/b3p/tailormap/api/exception/TailormapConfigurationException.java
+++ b/src/main/java/nl/b3p/tailormap/api/exception/TailormapConfigurationException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.exception;
+
+/**
+ * A checked {@code Exception} to indicate a configuration problem in Tailormap.
+ *
+ * @author mprins
+ * @since 0.1
+ */
+public class TailormapConfigurationException extends TailormapException {
+    public TailormapConfigurationException() {
+        super();
+    }
+
+    public TailormapConfigurationException(String message) {
+        super(message);
+    }
+
+    public TailormapConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TailormapConfigurationException(Throwable cause) {
+        super(cause);
+    }
+
+    protected TailormapConfigurationException(
+            String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/nl/b3p/tailormap/api/exception/TailormapException.java
+++ b/src/main/java/nl/b3p/tailormap/api/exception/TailormapException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.exception;
+
+/**
+ * General checked {@code Exception} for Tailormap. Prefer to use more specific exceprions.
+ *
+ * @author mprins
+ * @since 0.1
+ */
+public class TailormapException extends Exception {
+    public TailormapException() {
+        super();
+    }
+
+    public TailormapException(String message) {
+        super(message);
+    }
+
+    public TailormapException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TailormapException(Throwable cause) {
+        super(cause);
+    }
+
+    protected TailormapException(
+            String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}


### PR DESCRIPTION
`/app` endpoint returned HTTP 200 with HTTP 500 error payload on misconfiguration, will now return 500