### PR TITLE
[HTM-309] Change management port to 9090

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY ./target/tailormap-api-exec.jar tailormap-api.jar
 
 EXPOSE 8080
 # see https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#health
-HEALTHCHECK --interval=25s --timeout=3s --retries=2 CMD wget -nv --spider --tries=1 --no-verbose --header 'Accept: application/json' http://127.0.0.1:8080/api/actuator/health || exit 1
+HEALTHCHECK --interval=25s --timeout=3s --retries=2 CMD wget -nv --spider --tries=1 --no-verbose --header 'Accept: application/json' http://127.0.0.1:9090/api/actuator/health || exit 1
 
 # note that Spring Boot logs to the console, there is no logfile
 ENTRYPOINT ["java", "-jar", "tailormap-api.jar"]

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,15 +16,14 @@ spring.datasource.pool-size=30
 
 spring.jpa.show-sql=true
 
-# we don't need JMX
-spring.jmx.enabled=false
-
 # actuator
 # TODO set up security
 # management.endpoint.health.show-details=when_authorized
 # management.endpoint.health.roles=
 management.endpoint.health.show-details=always
 management.health.tailormap.enabled=true
+management.server.port=9090
+management.server.base-path=/api
 
 logging.level.org.springframework.boot.autoconfigure=INFO
 logging.level.org.springframework.test.context=INFO


### PR DESCRIPTION
this port does not have to be publicly exposed, maybe needs a change in the traefik config and nginx reverse proxy config of https://github.com/B3Partners/tailormap-viewer to make it accessible outside the container stack if that is needed at all - I think it would be better to connect any monitoring application into the `tailormap-viewer` network