### PR TITLE
Return hidpi options for services and layers

### DIFF
--- a/src/main/resources/model.yaml
+++ b/src/main/resources/model.yaml
@@ -128,6 +128,17 @@ components:
         legendImageUrl:
           description: URL to an image with the layer legend.
           type: string
+        hiDpiMode:
+          type: string
+          description: 'For tiled services only'
+          enum:
+            - disabled
+            - showNextZoomLevel
+            - substituteLayerShowNextZoomLevel
+            - substituteLayerTilePixelRatioOnly
+        hiDpiSubstituteLayer:
+          description: 'The layer name of this service to substitute when the device pixel ratio is higher'
+          type: string
       required:
         - id
         - layerName
@@ -374,6 +385,17 @@ components:
           default: false
         styleLibraries:
           type: object
+        hiDpiMode:
+          type: string
+          enum:
+            - auto
+            - disabled
+            - geoserver
+            - mapserver
+        tilingDisabled:
+          type: boolean
+        tilingGutter:
+          type: integer
         protocol:
           type: string
           enum:


### PR DESCRIPTION
HTM-48

Note that this includes a recursive method to find a service layer by name which should be implemented in an optimized way instead, but that is tracked in HTM-327.

see https://github.com/B3Partners/tailormap-admin/pull/92