### PR TITLE
[HTM-272][HTM-327] Add support for proper layer titles, authorisation

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/controller/MapController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/MapController.java
@@ -21,6 +21,7 @@ import nl.b3p.tailormap.api.model.LayerTreeNode;
 import nl.b3p.tailormap.api.model.MapResponse;
 import nl.b3p.tailormap.api.model.RedirectResponse;
 import nl.b3p.tailormap.api.model.Service;
+import nl.b3p.tailormap.api.repository.ApplicationLayerRepository;
 import nl.b3p.tailormap.api.repository.ApplicationRepository;
 import nl.b3p.tailormap.api.repository.LayerRepository;
 import nl.b3p.tailormap.api.repository.LevelRepository;
@@ -42,6 +43,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -57,8 +60,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import javax.persistence.EntityNotFoundException;
 import javax.validation.constraints.NotNull;
@@ -69,6 +75,7 @@ import javax.validation.constraints.NotNull;
 public class MapController {
     private final Log logger = LogFactory.getLog(getClass());
     @Autowired private ApplicationRepository applicationRepository;
+    @Autowired private ApplicationLayerRepository applicationLayerRepository;
     @Autowired private LevelRepository levelRepository;
     @Autowired private LayerRepository layerRepository;
 
@@ -107,11 +114,10 @@ public class MapController {
                     Long appId) {
         logger.trace("Requesting 'map' for application id: " + appId);
 
-        // this could throw EntityNotFound, which is handles by handleEntityNotFoundException
-        // and in a normal flow this should not happen
-        // as appId is (should be) validated by calling the /app/ endpoint
-        Application application = applicationRepository.getReferenceById(appId);
-        if (application.isAuthenticatedRequired() && !AuthUtil.isAuthenticatedUser()) {
+        Application application = applicationRepository.findWithGeoservicesById(appId);
+        if (application == null) {
+            throw new EntityNotFoundException();
+        } else if (application.isAuthenticatedRequired() && !AuthUtil.isAuthenticatedUser()) {
             // login required, send RedirectResponse
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new RedirectResponse());
         } else {
@@ -170,12 +176,20 @@ public class MapController {
         mapResponse.crs(c).maxExtent(maxExtent).initialExtent(initialExtent);
     }
 
-    private String getNameForAppLayer(@NotNull ApplicationLayer layer) {
+    private String getNameForAppLayer(
+            @NotNull ApplicationLayer layer, @NotNull List<Layer> layers) {
         if (ClobElement.isNotBlank(layer.getDetails().get("titleAlias"))) {
             return layer.getDetails().get("titleAlias").getValue();
         } else {
-            Layer serviceLayer =
-                    layerRepository.getByServiceAndName(layer.getService(), layer.getLayerName());
+            Layer serviceLayer = null;
+            for (Layer possibleLayer : layers) {
+                if (possibleLayer.getService().equals(layer.getService())
+                        && Objects.equals(possibleLayer.getName(), layer.getLayerName())) {
+                    serviceLayer = possibleLayer;
+                    break;
+                }
+            }
+
             if (serviceLayer != null) {
                 return serviceLayer.getDisplayName();
             } else {
@@ -184,7 +198,23 @@ public class MapController {
         }
     }
 
+    private static boolean isAuthorized(Set<String> readers, Authentication auth) {
+        if (readers == null || readers.isEmpty()) {
+            return true;
+        }
+
+        for (String reader : readers) {
+            if (auth.getAuthorities().stream().anyMatch(x -> x.getAuthority().equals(reader))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private void getLayers(@NotNull Application a, @NotNull MapResponse mapResponse) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
         LayerTreeNode rootNode = new LayerTreeNode().id("root").root(true).name("Foreground");
         mapResponse.addLayerTreeNodesItem(rootNode);
 
@@ -192,33 +222,140 @@ public class MapController {
                 new LayerTreeNode().id("rootbg").root(true).name("Background");
         mapResponse.addBaseLayerTreeNodesItem(rootBackgroundNode);
 
-        levelRepository.findByLevelTree(a.getRoot().getId());
-        List<StartLayer> startLayers = a.getStartLayers();
-        List<StartLevel> startLevels = a.getStartLevels();
+        List<Long> ids = new ArrayList<>();
+        Map<Long, List<Level>> levelChildrenMap = new HashMap<>();
+        for (Level level : levelRepository.findByLevelTree(a.getRoot().getId())) {
+            if (level.getParent() != null) {
+                levelChildrenMap
+                        .computeIfAbsent(level.getParent().getId(), (Long t) -> new ArrayList<>())
+                        .add(level);
+            }
+            ids.add(level.getId());
+        }
 
-        // Build a map of layer id -> StartLayer.
+        // Preload the list of levels, layers, and their readers into the repository's cache.
+        // Note that the result of this is not used directly; this merely ensures that
+        // `level.getLayers()` doesn't need another roundtrip later.
+        levelRepository.findWithAuthorizationDataByIdIn(ids);
+
+        // List of used ApplicationLayer IDs in this map.
+        Set<Long> applicationLayerIds = new HashSet<>();
+
+        List<StartLayer> startLayers = a.getStartLayers();
+        for (StartLayer startLayer : startLayers) {
+            if (startLayer.isRemoved()) {
+                continue;
+            }
+
+            applicationLayerIds.add(startLayer.getApplicationLayer().getId());
+        }
+
+        // As above, preload the list of ApplicationLayers, their authorization, and details (used
+        // for display name). We already have handles to ApplicationLayers in the StartLayer
+        // objects.
+        applicationLayerRepository.findWithReadersAndDetailsByIdIn(applicationLayerIds);
+
+        // Map of (authorized) ApplicationLayer ID to StartLayer objects.
         Map<Long, StartLayer> layerMap = new HashMap<>(startLayers.size());
         for (StartLayer startLayer : startLayers) {
             if (startLayer.isRemoved()) {
                 continue;
             }
 
-            layerMap.put(startLayer.getApplicationLayer().getId(), startLayer);
+            ApplicationLayer appLayer = startLayer.getApplicationLayer();
+            if (!isAuthorized(appLayer.getReaders(), authentication)) {
+                continue;
+            }
+            layerMap.put(appLayer.getId(), startLayer);
         }
 
-        // Remove any startLevels that aren't assigned in the startkaartbeeld
+        // Fetch the list of possible StartLevels, and filter them down to ones that aren't removed
+        // and are assigned an index.
+        List<StartLevel> startLevels = a.getStartLevels();
         startLevels.removeIf((StartLevel t) -> t.isRemoved() || t.getSelectedIndex() == null);
         startLevels.sort(Comparator.comparingLong(StartLevel::getSelectedIndex));
 
-        Map<Long, LayerTreeNode> treeNodeMap = new HashMap<>();
-        Deque<Level> levelQueue = new ArrayDeque<>();
+        // Authorized StartLevel IDs
+        Set<Long> visibleLevels = new HashSet<>();
         List<StartLayer> visibleStartLayers = new ArrayList<>();
 
+        // Iterate over startLevels twice. Once to figure out visibility and authentication, once to
+        // actually build the returned structure.
+        Deque<Level> levelQueue = new ArrayDeque<>();
+        for (StartLevel l : startLevels) {
+            levelQueue.add(l.getLevel());
+            while (!levelQueue.isEmpty()) {
+                Level level = levelQueue.pop();
+                if (visibleLevels.contains(level.getId())) {
+                    continue;
+                }
+
+                if (!isAuthorized(level.getReaders(), authentication)) {
+                    continue;
+                }
+
+                visibleLevels.add(level.getId());
+                levelQueue.addAll(levelChildrenMap.getOrDefault(level.getId(), List.of()));
+                for (ApplicationLayer layer : level.getLayers()) {
+                    StartLayer startLayer = layerMap.get(layer.getId());
+                    if (startLayer == null) {
+                        continue;
+                    }
+
+                    visibleStartLayers.add(startLayer);
+                }
+            }
+        }
+
+        // To check for visibility on the GeoService, we need each Layer and their parents. This
+        // could be done with a native query, however, we also need each layer's readers, which
+        // would require another roundtrip. Take the bandwidth hit and fetch all the used
+        // GeoServices' layers.
+        Set<Long> neededServiceIds = new HashSet<>();
+        for (StartLayer l : visibleStartLayers) {
+            neededServiceIds.add(l.getApplicationLayer().getService().getId());
+        }
+        List<Layer> layers = layerRepository.findByServiceIdIn(neededServiceIds);
+
+        // Check the visibility of each visible StartLayer's corresponding Layer.
+        for (StartLayer startLayer : visibleStartLayers) {
+            ApplicationLayer applicationLayer = startLayer.getApplicationLayer();
+            Layer serviceVisibilityLayer = null;
+            for (Layer l : layers) {
+                if (l.getService().equals(applicationLayer.getService())
+                        && Objects.equals(l.getName(), applicationLayer.getLayerName())) {
+                    serviceVisibilityLayer = l;
+                    break;
+                }
+            }
+
+            boolean isLayerVisible =
+                    isAuthorized(serviceVisibilityLayer.getService().getReaders(), authentication);
+            while (isLayerVisible && serviceVisibilityLayer != null) {
+                if (!isAuthorized(serviceVisibilityLayer.getReaders(), authentication)) {
+                    isLayerVisible = false;
+                    break;
+                }
+
+                serviceVisibilityLayer = serviceVisibilityLayer.getParent();
+            }
+
+            // If the Layer is not visible, remove the ApplicationLayer from the layerMap.
+            if (!isLayerVisible) {
+                layerMap.remove(applicationLayer.getId());
+            }
+        }
+
+        // Repopulate the visible StartLayer list while iterating over StartLevels, this time taking
+        // each Layer's visibility in account.
+        visibleStartLayers.clear();
+
+        Map<Long, LayerTreeNode> treeNodeMap = new HashMap<>();
         for (StartLevel l : startLevels) {
             // Check if this level is a child of a background level. In the API background levels
-            // are returned in a separate tree.
-            // Only children of the Level with isBackground() set to true can be a StartLevel, so we
-            // need to check all parents only (not the Level of the StartLevel itself).
+            // are returned in a separate tree. Only children of the Level with isBackground() set
+            // to true can be a StartLevel, so we need to check all parents only (not the Level of
+            // the StartLevel itself).
             boolean isBackground = false;
             Level parentLevel = l.getLevel();
             while (parentLevel != null && !isBackground) {
@@ -240,13 +377,13 @@ public class MapController {
             levelQueue.add(startLevel);
             while (!levelQueue.isEmpty()) {
                 Level level = levelQueue.pop();
-                if (treeNodeMap.containsKey(level.getId())) {
+                if (treeNodeMap.containsKey(level.getId())
+                        || !visibleLevels.contains(level.getId())) {
                     continue;
                 }
 
                 // Use a prefix to make the LayerTreeNode ids in the tree containing both Level and
                 // ApplicationLayer nodes unique
-
                 LayerTreeNode childNode =
                         new LayerTreeNode()
                                 .id(String.format("lvl_%d", level.getId()))
@@ -265,34 +402,40 @@ public class MapController {
                 }
                 parentNode.addChildrenIdsItem(childNode.getId());
 
-                levelQueue.addAll(level.getChildren());
+                levelQueue.addAll(levelChildrenMap.getOrDefault(level.getId(), List.of()));
                 for (ApplicationLayer layer : level.getLayers()) {
                     StartLayer startLayer = layerMap.get(layer.getId());
                     if (startLayer == null) {
                         continue;
                     }
 
+                    visibleStartLayers.add(startLayer);
+
                     LayerTreeNode layerNode =
                             new LayerTreeNode()
                                     .id(String.format("lyr_%d", layer.getId()))
-                                    .name(getNameForAppLayer(layer))
+                                    .name(getNameForAppLayer(layer, layers))
                                     .appLayerId((int) (long) layer.getId())
                                     .root(false)
                                     .childrenIds(new ArrayList<>());
 
                     treeNodeList.add(layerNode);
                     childNode.addChildrenIdsItem(layerNode.getId());
-                    visibleStartLayers.add(startLayer);
                 }
             }
         }
 
-        // Only add AppLayers visible in the LayerTreeNode graph to the response
+        // Only add ApplicationLayers visible in the LayerTreeNode graph to the response.
         for (StartLayer l : visibleStartLayers) {
-            Layer serviceLayer =
-                    layerRepository.getByServiceAndName(
-                            l.getApplicationLayer().getService(),
-                            l.getApplicationLayer().getLayerName());
+            ApplicationLayer applicationLayer = l.getApplicationLayer();
+            Layer serviceLayer = null;
+            for (Layer layer : layers) {
+                if (layer.getService().equals(applicationLayer.getService())
+                        && Objects.equals(layer.getName(), applicationLayer.getLayerName())) {
+                    serviceLayer = layer;
+                    break;
+                }
+            }
 
             AppLayer.HiDpiModeEnum hiDpiMode = null;
             String hiDpiSubstituteLayer = null;
@@ -321,10 +464,10 @@ public class MapController {
 
             AppLayer appLayer =
                     new AppLayer()
-                            .id(l.getApplicationLayer().getId())
-                            .layerName(l.getApplicationLayer().getLayerName())
-                            .title(getNameForAppLayer(l.getApplicationLayer()))
-                            .serviceId(l.getApplicationLayer().getService().getId())
+                            .id(applicationLayer.getId())
+                            .layerName(serviceLayer.getName())
+                            .title(getNameForAppLayer(applicationLayer, layers))
+                            .serviceId(applicationLayer.getService().getId())
                             .hiDpiMode(hiDpiMode)
                             .hiDpiSubstituteLayer(hiDpiSubstituteLayer)
                             .visible(l.isChecked())
@@ -332,7 +475,7 @@ public class MapController {
 
             mapResponse.addAppLayersItem(appLayer);
 
-            GeoService geoService = l.getApplicationLayer().getService();
+            GeoService geoService = applicationLayer.getService();
 
             // Use this default if saved before the form default was added in admin
             Service.HiDpiModeEnum serviceHiDpiMode = Service.HiDpiModeEnum.AUTO;

--- a/src/main/java/nl/b3p/tailormap/api/repository/ApplicationLayerRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/ApplicationLayerRepository.java
@@ -7,11 +7,20 @@ package nl.b3p.tailormap.api.repository;
 
 import nl.tailormap.viewer.config.app.ApplicationLayer;
 
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 /**
  * Easy to use methods to access {@link ApplicationLayer}.
  *
  * @since 0.1
  */
-public interface ApplicationLayerRepository extends JpaRepository<ApplicationLayer, Long> {}
+public interface ApplicationLayerRepository extends JpaRepository<ApplicationLayer, Long> {
+    @EntityGraph(
+            attributePaths = {"readers", "details"},
+            type = EntityGraphType.LOAD)
+    public List<ApplicationLayer> findWithReadersAndDetailsByIdIn(Iterable<Long> ids);
+}

--- a/src/main/java/nl/b3p/tailormap/api/repository/ApplicationRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/ApplicationRepository.java
@@ -7,6 +7,7 @@ package nl.b3p.tailormap.api.repository;
 
 import nl.tailormap.viewer.config.app.Application;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -23,6 +24,21 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     List<Application> findByName(String name);
 
     Application findByNameAndVersion(String name, String version);
+
+    /**
+     * Equivalent to findById, but preloads some of the necessary entities to limit the amount of
+     * roundtrips.
+     *
+     * @param id the ID of the Application to return
+     * @return the Application entity, with extra cached attributes.
+     */
+    @EntityGraph(
+            attributePaths = {
+                "startLayers.applicationLayer.service.details",
+                "startLayers.applicationLayer.service.readers",
+                "startLayers.applicationLayer.readers"
+            })
+    Application findWithGeoservicesById(Long id);
 
     @Transactional
     @Modifying

--- a/src/main/java/nl/b3p/tailormap/api/repository/LayerRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/LayerRepository.java
@@ -8,7 +8,10 @@ package nl.b3p.tailormap.api.repository;
 import nl.tailormap.viewer.config.services.GeoService;
 import nl.tailormap.viewer.config.services.Layer;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 /**
  * Easy to use methods to access {@link Layer}.
@@ -17,4 +20,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
  */
 public interface LayerRepository extends JpaRepository<Layer, Long> {
     public Layer getByServiceAndName(GeoService service, String name);
+
+    @EntityGraph(attributePaths = {"readers", "details"})
+    List<Layer> findByServiceIdIn(Iterable<Long> list);
 }

--- a/src/main/java/nl/b3p/tailormap/api/repository/LayerRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/LayerRepository.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2022 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.repository;
+
+import nl.tailormap.viewer.config.services.GeoService;
+import nl.tailormap.viewer.config.services.Layer;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Easy to use methods to access {@link Layer}.
+ *
+ * @since 0.1
+ */
+public interface LayerRepository extends JpaRepository<Layer, Long> {
+    public Layer getByServiceAndName(GeoService service, String name);
+}

--- a/src/main/java/nl/b3p/tailormap/api/repository/LevelRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/LevelRepository.java
@@ -7,6 +7,7 @@ package nl.b3p.tailormap.api.repository;
 
 import nl.tailormap.viewer.config.app.Level;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -23,4 +24,7 @@ public interface LevelRepository extends JpaRepository<Level, Long> {
                     "select * from level_ where id in (with recursive level_tree(id) as (select id from level_ where id = ?1 union all select l.id from level_tree, level_ l where l.parent = level_tree.id) select * from level_tree)",
             nativeQuery = true)
     List<Level> findByLevelTree(Long rootId);
+
+    @EntityGraph(attributePaths = {"readers", "layers.service", "layers.readers"})
+    List<Level> findWithAuthorizationDataByIdIn(Iterable<Long> ids);
 }


### PR DESCRIPTION
HTM-272
HTM-327
Combined PR as the authorization commit builds on top of the layer title commit. The layer title commit should be self-explanatory, so some details on the authorization commit:

To avoid the `n+1` issue with ORMs, this commit uses `EntityGraph`s to fetch most necessary components in one go, exchanging latency for bandwidth use. The SQL queries are visualised here to the best of my abilities:
```mermaid
flowchart TD
  %% query 1
  Application -->|findWithGeoservicesById| ApplicationLayer
  ApplicationLayer  -->|findWithGeoservicesById| GeoService

  %% query 2
  Level -->|findByLevelTree| Level

  %% query 3
  Level -->|findWithAuthorizationDataByIdIn| ApplicationLayer
  ApplicationLayer -->|findWithAuthorizationDataByIdIn| GeoService

  %% query 4
  %% just fetches ApplicationLayers that have not been fetched by previous queries?

  %% query 5
  ApplicationLayer -->|getStartLevels| StartLevel
  StartLevel -->|getStartLevels| Level

  %% query 6
  GeoService -->|findByServiceIdIn| Layer

  linkStyle 0,1 stroke:#ff9a56
  linkStyle 2 stroke:#ef7627
  linkStyle 3,4 stroke:#F5A9B8
  linkStyle 5,6 stroke:#b55690
  linkStyle 7 stroke:#5BCEFA
```

All of these queries, other than the native query (`findByLevelTree`) use methods on the respective entitiy's `JpaRepositories`,  with `@EntityGraph` as hints to Hibernate to fetch all necessary components.

The code filters out any `ApplicationLayer`, `Layer`, `GeoService`, or `Level` that has not been authorized to the current user's groups. However, if a `Level` contains one `Layer` that is filtered out, the `Level` it is in remains. This means that if a background `Layer` is not visible to the current user, it can still be selected in the viewer, but it will not show a proper map.