### PR TITLE
[HTM-397] Add git commit id to version info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -517,8 +517,20 @@ SPDX-License-Identifier: MIT
         </executions>
       </plugin>
       <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>5.0.0</version>
+        <configuration>
+          <generateGitPropertiesFile>false</generateGitPropertiesFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
@@ -592,6 +604,8 @@ SPDX-License-Identifier: MIT
             <!--suppress UnresolvedMavenProperty -->
             <API_VERSION>${info.version}</API_VERSION>
             <DATABASE_VERSION>${org.tailormap.database.version}</DATABASE_VERSION>
+            <!--suppress UnresolvedMavenProperty -->
+            <GIT_COMMIT_ID>${git.commit.id}</GIT_COMMIT_ID>
           </environmentVariables>
           <excludes>
             <exclude>**/*IntegrationTest.java</exclude>
@@ -618,6 +632,8 @@ SPDX-License-Identifier: MIT
             <!--suppress UnresolvedMavenProperty -->
             <API_VERSION>${info.version}</API_VERSION>
             <DATABASE_VERSION>${org.tailormap.database.version}</DATABASE_VERSION>
+            <!--suppress UnresolvedMavenProperty -->
+            <GIT_COMMIT_ID>${git.commit.id}</GIT_COMMIT_ID>
           </environmentVariables>
           <useFile>false</useFile>
           <classpathDependencyExcludes>
@@ -645,6 +661,8 @@ SPDX-License-Identifier: MIT
             <!--suppress UnresolvedMavenProperty -->
             <API_VERSION>${info.version}</API_VERSION>
             <DATABASE_VERSION>${org.tailormap.database.version}</DATABASE_VERSION>
+            <!--suppress UnresolvedMavenProperty -->
+            <GIT_COMMIT_ID>${git.commit.id}</GIT_COMMIT_ID>
           </environmentVariables>
           <cleanCache>true</cleanCache>
           <!--suppress UnresolvedMavenProperty -->
@@ -668,6 +686,7 @@ SPDX-License-Identifier: MIT
             <phase>pre-integration-test</phase>
             <configuration>
               <!-- <skip>${skipQA}</skip> -->
+              <!--suppress UnresolvedMavenProperty -->
               <skip>${skipTests}</skip>
               <profiles>
                 <profile>test</profile>
@@ -679,6 +698,8 @@ SPDX-License-Identifier: MIT
                 <!--suppress UnresolvedMavenProperty -->
                 <API_VERSION>${info.version}</API_VERSION>
                 <DATABASE_VERSION>${org.tailormap.database.version}</DATABASE_VERSION>
+                <!--suppress UnresolvedMavenProperty -->
+                <GIT_COMMIT_ID>${git.commit.id}</GIT_COMMIT_ID>
               </environmentVariables>
               <systemPropertyVariables>
                 <project.version>${project.version}</project.version>
@@ -1416,6 +1437,8 @@ SPDX-License-Identifier: MIT
                 <API_VERSION>${info.version}</API_VERSION>
                 <!-- TODO read this from persistence -->
                 <DATABASE_VERSION>${org.tailormap.database.version}</DATABASE_VERSION>
+                <!--suppress UnresolvedMavenProperty -->
+                <GIT_COMMIT_ID>${git.commit.id}</GIT_COMMIT_ID>
               </environmentVariables>
               <useFile>false</useFile>
             </configuration>
@@ -1439,6 +1462,7 @@ SPDX-License-Identifier: MIT
                 </goals>
                 <phase>pre-integration-test</phase>
                 <configuration>
+                  <!--suppress UnresolvedMavenProperty -->
                   <skip>${skipTests}</skip>
                   <profiles>
                     <profile>postgresql</profile>
@@ -1450,7 +1474,9 @@ SPDX-License-Identifier: MIT
                     <!--suppress UnresolvedMavenProperty -->
                     <API_VERSION>${info.version}</API_VERSION>
                     <!-- TODO read this from persistence -->
-                    <DATABASE_VERSION>47</DATABASE_VERSION>
+                    <DATABASE_VERSION>${org.tailormap.database.version}</DATABASE_VERSION>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <GIT_COMMIT_ID>${git.commit.id}</GIT_COMMIT_ID>
                   </environmentVariables>
                   <systemPropertyVariables>
                     <project.version>${project.version}</project.version>
@@ -1464,6 +1490,7 @@ SPDX-License-Identifier: MIT
                 </goals>
                 <phase>post-integration-test</phase>
                 <configuration>
+                  <!--suppress UnresolvedMavenProperty -->
                   <skip>${skipTests}</skip>
                 </configuration>
               </execution>

--- a/src/main/java/nl/b3p/tailormap/api/controller/VersionController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/VersionController.java
@@ -37,6 +37,9 @@ public class VersionController {
     @Value("${tailormap-api.apiVersion}")
     private String apiVersion;
 
+    @Value("${tailormap-api.commitSha}")
+    private String commitSha;
+
     /**
      * get API version.
      *
@@ -52,8 +55,8 @@ public class VersionController {
 
         logger.debug(
                 String.format(
-                        "Version information:\n\tproduct version: %s\n\tdatabase version: %s\n\tAPI version: %s",
-                        this.version, dbVersion, this.apiVersion));
+                        "Version information:\n\tproduct version: %s\n\tdatabase version: %s\n\tAPI version: %s\n\tgit commit: %s",
+                        this.version, dbVersion, this.apiVersion, this.commitSha));
 
         return Map.of(
                 "version",
@@ -61,6 +64,8 @@ public class VersionController {
                 "databaseversion",
                 dbVersion,
                 "apiVersion",
-                this.apiVersion);
+                this.apiVersion,
+                "commitSha",
+                this.commitSha);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,8 @@
 tailormap-api.version=@project.version@
 # api version
 tailormap-api.apiVersion=@info.version@
+# commit sha
+tailormap-api.commitSha=@git.commit.id@
 # name
 tailormap-api.name=@project.artifactId@
 # base url

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>@project.name@</title>
+    <title>@project.name@ @project.version@</title>
 </head>
 <body>
-<h1>@project.name@</h1>
+<h1>@project.name@ @project.version@</h1>
 <p>@project.description@</p>
 <p>Service definition: <a href="swagger-ui/index.html">tailormap-api.yaml</a></p>
 </body>

--- a/src/main/resources/tailormap-api.yaml
+++ b/src/main/resources/tailormap-api.yaml
@@ -219,6 +219,7 @@ paths:
                 version: '0.1-SNAPSHOT'
                 databaseversion: '49'
                 apiVersion: 'v1'
+                commitSha: 'b8f8f8f'
 
 
   /login:

--- a/src/test/java/nl/b3p/tailormap/api/controller/VersionControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/VersionControllerIntegrationTest.java
@@ -46,6 +46,9 @@ class VersionControllerIntegrationTest {
         String apiVersion = System.getenv("API_VERSION");
         assumeFalse(null == apiVersion, "API version unknown, should be set in system environment");
 
+        String commitSha = System.getenv("GIT_COMMIT_ID");
+        assumeFalse(null == commitSha, "Git commit unknown, should be set in system environment");
+
         Map<String, String> expected =
                 Map.of(
                         "version",
@@ -53,7 +56,9 @@ class VersionControllerIntegrationTest {
                         "databaseversion",
                         databaseVersion,
                         "apiVersion",
-                        apiVersion);
+                        apiVersion,
+                        "commitSha",
+                        commitSha);
 
         assertEquals(expected, versionController.getVersion(), "Unexpected version response.");
     }
@@ -72,6 +77,9 @@ class VersionControllerIntegrationTest {
         String apiVersion = System.getenv("API_VERSION");
         assumeFalse(null == apiVersion, "API version unknown, should be set in system environment");
 
+        String commitSha = System.getenv("GIT_COMMIT_ID");
+        assumeFalse(null == commitSha, "Git commit unknown, should be set in system environment");
+
         assertNotNull(versionController.getVersion(), "Version info not found");
         Map<String, String> expected =
                 Map.of(
@@ -80,7 +88,9 @@ class VersionControllerIntegrationTest {
                         "databaseversion",
                         "unknown",
                         "apiVersion",
-                        apiVersion);
+                        apiVersion,
+                        "commitSha",
+                        commitSha);
 
         assertEquals(expected, versionController.getVersion(), "Unexpected version response.");
     }

--- a/src/test/resources/application-postgresql.properties
+++ b/src/test/resources/application-postgresql.properties
@@ -2,6 +2,8 @@
 tailormap-api.version=@project.version@
 # api version
 tailormap-api.apiVersion=@info.version@
+# commit sha
+tailormap-api.commitSha=@git.commit.id@
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,6 +2,8 @@
 tailormap-api.version=@project.version@
 # api version
 tailormap-api.apiVersion=@info.version@
+# commit sha
+tailormap-api.commitSha=@git.commit.id@
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 


### PR DESCRIPTION
resolves HTM-397

calling `/api/version` will produce something like 
```json 
{"version":"0.1-SNAPSHOT",
"commitSha":"05b3fce1e2991972642dc8a656d013c455e889ea",
"apiVersion":"v1","databaseversion":"47"}
```