### PR TITLE
Try to resolve integration test failures on merged branch integration test build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -649,6 +649,10 @@ SPDX-License-Identifier: MIT
           <cleanCache>true</cleanCache>
           <!--suppress UnresolvedMavenProperty -->
           <jvmArguments>${surefireArgLine}</jvmArguments>
+          <!-- wait between attempts, default 500 ms -->
+          <wait>1000</wait>
+          <!-- max attempts to check if application is up, default 60 -->
+          <maxAttempts>120</maxAttempts>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
by increasing both the number of times a check for a running application is done as well as the interval between checks