### PR TITLE
Bump hibernate.version from 5.6.9.Final to 5.6.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ SPDX-License-Identifier: MIT
     <!-- jackson-bom.version>2.13.2.1</jackson-bom.version -->
     <!-- micrometer.version>1.9.1</micrometer.version -->
     <!-- make sure to keep this hibernate version and that of tailormap persistence version in sync -->
-    <hibernate.version>5.6.9.Final</hibernate.version>
+    <hibernate.version>5.6.10.Final</hibernate.version>
     <hsqldb.version>2.6.1</hsqldb.version>
     <postgresql.version>42.4.0</postgresql.version>
     <oracle-database.version>21.6.0.0.1</oracle-database.version>


### PR DESCRIPTION
see also https://github.com/B3Partners/tailormap-persistence/pull/4


Bumps `hibernate.version` from 5.6.9.Final to 5.6.10.Final.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/hibernate/hibernate-orm/blob/5.6.10/changelog.txt">hibernate-core's changelog</a>.</em></p>
<blockquote>
<h2>Changes in 5.6.10.Final (July 07, 2022)</h2>
<p><a href="https://hibernate.atlassian.net/projects/HHH/versions/32076">https://hibernate.atlassian.net/projects/HHH/versions/32076</a></p>
<p>** Bug
* [HHH-15281] - INSERTs/UPDATEs no longer executed as JDBC Batch statements if hibernate.temp.use_jdbc_metadata_defaults is set to false
* [HHH-15218] - <a href="https://github.com/OptimisticLocking"><code>@​OptimisticLocking</code></a>(DIRTY) leads to wrong query during delete of circular reference
* [HHH-7525] - <a href="https://github.com/Formula"><code>@​Formula</code></a> annotation with native query returning entity value causes NullPointerException</p>
<p>** Improvement
* [HHH-15325] - Avoid allocations from BitSet.stream() in AbstractEntityPersister.resolveDirtyAttributeIndexes()</p>
<p>** Task
* [HHH-15322] - Allow JNDI lookups using the osgi scheme</p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/hibernate/hibernate-orm/commit/a900ace185c320b097dbf1e16145d2faad8d9913"><code>a900ace</code></a> 5.6.10.Final</li>
<li><a href="https://github.com/hibernate/hibernate-orm/commit/c53050c7c3569cded547daa690e2081ace5d6ceb"><code>c53050c</code></a> HHH-15322 Allow JNDI lookups using the osgi scheme</li>
<li><a href="https://github.com/hibernate/hibernate-orm/commit/6b4ac625e1fc721ea30d45ee069d75af7357b91d"><code>6b4ac62</code></a> HHH-15218 <a href="https://github.com/OptimisticLocking"><code>@​OptimisticLocking</code></a>(DIRTY) leads to wrong query during delete of cir...</li>
<li><a href="https://github.com/hibernate/hibernate-orm/commit/3f5b12c9e55ce351933792b7341ff7884995fadc"><code>3f5b12c</code></a> HHH-15218 Add test for issue</li>
<li><a href="https://github.com/hibernate/hibernate-orm/commit/835374328f1961e4edcf16c816b8f03d17f3bea9"><code>8353743</code></a> Update hibernate-core/src/main/java/org/hibernate/loader/ColumnEntityAliases....</li>
<li><a href="https://github.com/hibernate/hibernate-orm/commit/828a1921a7538584ba3dfd81ac2425073f359fd1"><code>828a192</code></a> HHH-7525 Reintroduce FailureExpected test case</li>
<li><a href="https://github.com/hibernate/hibernate-orm/commit/665004f16f3d40ececc7e1a86195bb22e0aa6aad"><code>665004f</code></a> HHH-7525 For <a href="https://github.com/Formula"><code>@​Formula</code></a>, use property name when there is no column name.</li>
<li><a href="https://github.com/hibernate/hibernate-orm/commit/a69ffc8b0ad9e1d4df35f221d53fdedfce16f347"><code>a69ffc8</code></a> HHH-15325 Avoid allocations from BitSet.stream() in AbstractEntityPersister</li>
<li><a href="https://github.com/hibernate/hibernate-orm/commit/4159a7b8dc1cbc039b525db68af9562f5ebd2206"><code>4159a7b</code></a> HHH-15281 INSERTs/UPDATEs no longer executed as JDBC Batch statements if hibe...</li>
<li><a href="https://github.com/hibernate/hibernate-orm/commit/54b98d04694c124a96348c912242ef8d32478c87"><code>54b98d0</code></a> HHH-15281 Add test for issue</li>
<li>Additional commits viewable in <a href="https://github.com/hibernate/hibernate-orm/compare/5.6.9...5.6.10">compare view</a></li>
</ul>
</details>
<br />
