### PR TITLE
Bump hibernate.version from 5.6.10.Final to 5.6.11.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@ SPDX-License-Identifier: MIT
     <!-- jackson-bom.version>2.13.3</jackson-bom.version -->
     <micrometer.version>1.9.3</micrometer.version>
     <!-- make sure to keep this hibernate version and that of tailormap persistence version in sync -->
-    <hibernate.version>5.6.10.Final</hibernate.version>
+    <hibernate.version>5.6.11.Final</hibernate.version>
     <hsqldb.version>2.7.0</hsqldb.version>
     <postgresql.version>42.5.0</postgresql.version>
     <oracle-database.version>21.6.0.0.1</oracle-database.version>


### PR DESCRIPTION
Bumps `hibernate.version` from 5.6.10.Final to 5.6.11.Final.

Updates `hibernate-core` from 5.6.10.Final to 5.6.11.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/5.6.11/changelog.txt)
- [Commits](hibernate/hibernate-orm@5.6.10...5.6.11)

Updates `hibernate-entitymanager` from 5.6.10.Final to 5.6.11.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/5.6.11/changelog.txt)
- [Commits](hibernate/hibernate-orm@5.6.10...5.6.11)


related https://github.com/B3Partners/tailormap-persistence/pull/24