### PR TITLE
[HTM-453] send min/max scale as part of the appLayer

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/controller/MapController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/MapController.java
@@ -471,6 +471,8 @@ public class MapController {
                             .hiDpiMode(hiDpiMode)
                             .hiDpiSubstituteLayer(hiDpiSubstituteLayer)
                             .visible(l.isChecked())
+                            .maxScale(serviceLayer.getMaxScale())
+                            .minScale(serviceLayer.getMinScale())
                             .hasAttributes(!l.getApplicationLayer().getAttributes().isEmpty());
 
             mapResponse.addAppLayersItem(appLayer);

--- a/src/main/resources/model.yaml
+++ b/src/main/resources/model.yaml
@@ -122,9 +122,11 @@ components:
         minScale:
           description: Minimum scale at which this layer should be shown or is not blank. When absent there is no minimum. As reported by the service (ScaleHint or MinScaleDenominator).
           type: number
+          format: double
         maxScale:
           description: Maximum scale denominator at which this layer should be shown or is not blank. When absent there is no maximum. As reported by the service (ScaleHint or MaxScaleDenominator).
           type: number
+          format: double
         legendImageUrl:
           description: URL to an image with the layer legend.
           type: string


### PR DESCRIPTION
this will show like:
```json
   {
      "id": 9,
      "layerName": "sqlserver:wegdeel",
      "title": "wegdeel",
      "serviceId": 6,
      "visible": true,
      "minScale": 0.0,
      "maxScale": 5000.0,
      "legendImageUrl": null,
      "hiDpiMode": null,
      "hiDpiSubstituteLayer": null,
      "hasAttributes": true
    },
    {
      "id": 6,
      "layerName": "postgis:begroeidterreindeel",
      "title": "begroeidterreindeel",
      "serviceId": 6,
      "visible": true,
      "minScale": null,
      "maxScale": null,
      "legendImageUrl": null,
      "hiDpiMode": null,
      "hiDpiSubstituteLayer": null,
      "hasAttributes": true
    },
```
eg. when you call https://snapshot.tailormap.nl/api/app/1/map


resolves HTM-543