### PR TITLE
[HTM-455] Implement ECQL filtering for the features endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ buildNumber.properties
 
 .idea/
 *.iml
+.run

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,9 @@ tailormap-api.apiVersion=@info.version@
 tailormap-api.commitSha=@git.commit.id@
 # name
 tailormap-api.name=@project.artifactId@
+# whether the api should attempt to provide exact feature counts for all WFS requests
+# may result in double query execution, once for counting and once for the actual data
+tailormap-api.wfs.count.exact=false
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 

--- a/src/main/resources/tailormap-api.yaml
+++ b/src/main/resources/tailormap-api.yaml
@@ -531,7 +531,12 @@ paths:
           schema:
             type: boolean
             default: false
-        - description: 'a filter to be applied, possibly in combination with any other request parameters'
+        - description: '
+            A filter to be applied, possibly in combination with any other request parameters. 
+            The filter is an ECQL string, see [ECQL reference](https://docs.geoserver.org/latest/en/user/filter/ecql_reference.html).
+            Filtering is supported when requesting a page of features, not when requesting a single 
+            feature (using `__fid`) nor when using x/y coordinates.
+            '
           in: query
           name: filter
           required: false

--- a/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerIntegrationTest.java
@@ -42,7 +42,7 @@ class FeaturesControllerIntegrationTest {
 
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-    void filter_not_supported() throws Exception {
+    void only_filter_not_supported() throws Exception {
         mockMvc.perform(get("/app/1/layer/2/features").param("filter", "naam=Utrecht"))
                 .andExpect(status().is4xxClientError())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/src/test/resources/application-postgresql.properties
+++ b/src/test/resources/application-postgresql.properties
@@ -4,6 +4,9 @@ tailormap-api.version=@project.version@
 tailormap-api.apiVersion=@info.version@
 # commit sha
 tailormap-api.commitSha=@git.commit.id@
+# whether the api should attempt to provide exact feature counts for all WFS requests
+# may result in double query execution, once for counting and once for the actual data
+tailormap-api.wfs.count.exact=false
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -4,6 +4,9 @@ tailormap-api.version=@project.version@
 tailormap-api.apiVersion=@info.version@
 # commit sha
 tailormap-api.commitSha=@git.commit.id@
+# whether the api should attempt to provide exact feature counts for all WFS requests
+# may result in double query execution, once for counting and once for the actual data
+tailormap-api.wfs.count.exact=false
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 


### PR DESCRIPTION
see ECQL documentation at https://docs.geotools.org/latest/userguide/library/cql/ecql.html and https://github.com/geotools/geotools/blob/main/modules/library/cql/ECQL.md

- [x] equals
- [x] greater than
- [x] less than
- [x] equals or greater than
- [x] equals or less than
- [x] in between
- [x] not in between / outside
- [x] null value
- [x] not null value
- [x] date equals w/ string argument (automatic conversion)
- [x] date equals w/ TEQUALS function
- [x] before date
- [x] after date
- [x] between dates
- [x] not between dates (before start or after end datetime)
- [x] like
- [x] not like
- [x] various OR
- [x] various AND

Please check the attached integration test for filter examples.

This PR also adds a property to attempt to provide exact feature counts for all (WFS) requests (as some WFS counts will return `-1` this may result in double query execution, once for counting and once for the actual data, default is `false`.
https://github.com/B3Partners/tailormap-api/blob/611d7457cde00c173de3ad1bfd54773b0353ac66/src/main/resources/application.properties#L9-L11

resolves HTM-455