### PR TITLE
[HTM-457, HTM-458, HTM-459, HTM-473] Implement unique attributes endpoint for Postgis, Oracle, SQL Server and (Geoserver) WFS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,6 @@ SPDX-License-Identifier: MIT
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
     </dependency>
     <dependency>
       <!-- this has "testdata.sql" that can be use to setup a HSQLDB test database -->

--- a/src/main/java/nl/b3p/tailormap/api/controller/UniqueValuesController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/UniqueValuesController.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.controller;
+
+import io.micrometer.core.annotation.Timed;
+import io.swagger.v3.oas.annotations.Parameter;
+
+import nl.b3p.tailormap.api.exception.BadRequestException;
+import nl.b3p.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
+import nl.b3p.tailormap.api.model.ErrorResponse;
+import nl.b3p.tailormap.api.model.RedirectResponse;
+import nl.b3p.tailormap.api.model.UniqueValuesResponse;
+import nl.b3p.tailormap.api.repository.ApplicationLayerRepository;
+import nl.b3p.tailormap.api.repository.ApplicationRepository;
+import nl.b3p.tailormap.api.security.AuthUtil;
+import nl.tailormap.viewer.config.app.Application;
+import nl.tailormap.viewer.config.app.ApplicationLayer;
+import nl.tailormap.viewer.config.services.Layer;
+import nl.tailormap.viewer.config.services.SimpleFeatureType;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geotools.data.Query;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.util.factory.GeoTools;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.expression.Function;
+import org.opengis.filter.sort.SortOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Set;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.PersistenceContext;
+
+@RestController
+@Validated
+@RequestMapping(
+        path = "/app/{appId}/layer/{appLayerId}/unique/{attributeName}",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+public class UniqueValuesController {
+    @Value("${tailormap-api.data.useGeotoolsUniqueFunction:true}")
+    private boolean useGeotoolsUniqueFunction;
+
+    private final FilterFactory2 ff =
+            CommonFactoryFinder.getFilterFactory2(GeoTools.getDefaultHints());
+    private final Log logger = LogFactory.getLog(getClass());
+    private final ApplicationRepository applicationRepository;
+    private final ApplicationLayerRepository applicationLayerRepository;
+    @PersistenceContext private EntityManager entityManager;
+
+    @Autowired
+    public UniqueValuesController(
+            ApplicationRepository applicationRepository,
+            ApplicationLayerRepository applicationLayerRepository) {
+        this.applicationRepository = applicationRepository;
+        this.applicationLayerRepository = applicationLayerRepository;
+    }
+
+    /**
+     * Handle any {@code EntityNotFoundException} that this controller might throw while getting the
+     * application.
+     *
+     * @param exception the exception
+     * @return an error response
+     */
+    @ExceptionHandler(EntityNotFoundException.class)
+    @ResponseStatus(
+            value =
+                    HttpStatus
+                            .NOT_FOUND /*,reason = "Not Found" -- adding 'reason' will drop the body */)
+    @ResponseBody
+    public ErrorResponse handleEntityNotFoundException(EntityNotFoundException exception) {
+        logger.warn(
+                "Requested an application or appLayer that does not exist. Message: "
+                        + exception.getMessage());
+        return new ErrorResponse()
+                .message("Requested an application or appLayer that does not exist")
+                .code(HttpStatus.NOT_FOUND.value());
+    }
+
+    /**
+     * Handle any {@code BadRequestException} that this controller might throw while getting the
+     * application.
+     *
+     * @param exception the exception
+     * @return an error response
+     */
+    @ExceptionHandler(BadRequestException.class)
+    @ResponseStatus(
+            value =
+                    HttpStatus
+                            .BAD_REQUEST /*,reason = "Bad Request" -- adding 'reason' will drop the body */)
+    @ResponseBody
+    public ErrorResponse handleBadRequestException(BadRequestException exception) {
+        return new ErrorResponse().message("Bad Request. " + exception.getMessage()).code(400);
+    }
+
+    /**
+     * Get a list of unique attribute values for a given attribute name.
+     *
+     * @param appId the application
+     * @param appLayerId the application layer id
+     * @param attributeName the attribute name
+     * @param filter A filter that was already applied to the layer (on a different attribute or
+     *     this attribute)
+     * @return a list of unique values, can be empty
+     * @throws BadRequestException if the request was invalid, eg. the provided filter could not be
+     *     parsed
+     */
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed(
+            value = "get_unique_attributes",
+            description = "time spent to process get unique attributes call")
+    public ResponseEntity<Serializable> getUniqueAttributes(
+            @Parameter(name = "appId", description = "application id", required = true)
+                    @PathVariable("appId")
+                    Long appId,
+            @Parameter(name = "appLayerId", description = "application layer id", required = true)
+                    @PathVariable("appLayerId")
+                    Long appLayerId,
+            @Parameter(name = "attributeName", description = "attribute name", required = true)
+                    @PathVariable("attributeName")
+                    String attributeName,
+            @RequestParam(required = false) String filter)
+            throws BadRequestException {
+
+        // this could throw EntityNotFound, which is handled by #handleEntityNotFoundException
+        // and in a normal flow this should not happen
+        // as appId is (should be) validated by calling the /app/ endpoint
+        final Application application = applicationRepository.getReferenceById(appId);
+        if (application.isAuthenticatedRequired() && !AuthUtil.isAuthenticatedUser()) {
+            // login required, send RedirectResponse
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new RedirectResponse());
+        } else {
+            if (StringUtils.isBlank(attributeName)) {
+                throw new BadRequestException("Attribute name is required");
+            }
+            final ApplicationLayer appLayer =
+                    applicationLayerRepository.getReferenceById(appLayerId);
+
+            UniqueValuesResponse uniqueValuesResponse =
+                    getUniqueValues(appLayer, attributeName, filter);
+            return ResponseEntity.status(HttpStatus.OK).body(uniqueValuesResponse);
+        }
+    }
+
+    private UniqueValuesResponse getUniqueValues(
+            ApplicationLayer appLayer, String attributeName, String filter)
+            throws BadRequestException {
+        final UniqueValuesResponse uniqueValuesResponse =
+                new UniqueValuesResponse().filterApplied(false);
+        final Layer layer = appLayer.getService().getLayer(appLayer.getLayerName(), entityManager);
+        final SimpleFeatureType sft = layer.getFeatureType();
+        if (null == sft) {
+            return uniqueValuesResponse;
+        }
+
+        try {
+            Filter existingFilter = null;
+            if (null != filter) {
+                existingFilter = ECQL.toFilter(filter);
+            }
+            logger.trace("existingFilter: " + existingFilter);
+
+            Filter notNull = ff.not(ff.isNull(ff.property(attributeName)));
+            Filter f = notNull;
+            if (null != existingFilter) {
+                f = ff.and(notNull, existingFilter);
+                uniqueValuesResponse.filterApplied(true);
+            }
+
+            Query q = new Query(sft.getTypeName(), f);
+            q.setPropertyNames(attributeName);
+            q.setSortBy(ff.sort(attributeName, SortOrder.ASCENDING));
+            logger.trace("Unique values query: " + q);
+
+            SimpleFeatureSource fs = FeatureSourceFactoryHelper.openGeoToolsFeatureSource(sft);
+            // and then there are 2 scenarios:
+            // there might be a performance benefit for one or the other
+            if (!useGeotoolsUniqueFunction) {
+                // #1 use a feature visitor to get the unique values
+                // not recommended, as it may not be performant
+                logger.trace("Using feature visitor to get unique values");
+                fs.getFeatures(q)
+                        .accepts(
+                                feature ->
+                                        uniqueValuesResponse.addValuesItem(
+                                                feature.getProperty(attributeName).getValue()),
+                                null);
+            } else {
+                // #2 or use a Function to get the unique values
+                // this is the recommended way, uses SLQ "distinct"
+                logger.trace("Using geotools unique collection function to get unique values");
+                Function unique = ff.function("Collection_Unique", ff.property(attributeName));
+                Object o = unique.evaluate(fs.getFeatures(q));
+                if (o instanceof Set) {
+                    @SuppressWarnings("unchecked")
+                    Set<Object> uniqueValues = (Set<Object>) o;
+                    uniqueValuesResponse.setValues(uniqueValues);
+                }
+            }
+
+            fs.getDataStore().dispose();
+        } catch (CQLException e) {
+            logger.error("Could not parse requested filter.", e);
+            throw new BadRequestException("Could not parse requested filter.");
+        } catch (IOException e) {
+            logger.error("Could not retrieve attribute data.", e);
+        }
+
+        return uniqueValuesResponse;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,10 @@ tailormap-api.name=@project.artifactId@
 # whether the api should attempt to provide exact feature counts for all WFS requests
 # may result in double query execution, once for counting and once for the actual data
 tailormap-api.wfs.count.exact=false
+# whether the API should use GeoTools "Unique Collection" (use DISTINCT in SQL statements) or just retrieve all
+# values when calculating the unique values for a property.
+# There might be a performance difference between the two, depending on the data
+tailormap-api.data.useGeotoolsUniqueFunction=true
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 
@@ -37,6 +41,9 @@ spring.jpa.properties[hibernate.generate_statistics]=true
 
 # actuator
 management.endpoints.enabled-by-default=false
+# provide mappings
+# management.endpoint.mappings.enabled=true
+# management.endpoints.web.exposure.include=info,health,metrics,prometheus,loggers,logfile,mappings
 management.endpoints.web.exposure.include=info,health,metrics,prometheus,loggers,logfile
 # we don't have a logfile configured, so this will return 404
 management.endpoint.logfile.enabled=true
@@ -65,7 +72,9 @@ logging.level.org.springframework.test.context=INFO
 
 logging.level.org.hibernate=INFO
 logging.level.org.hibernate.SQL=INFO
-# no hibernate session metrics in the log file
+# no hibernate session metrics in the log
 logging.level.org.hibernate.engine.internal.StatisticalLoggingSessionEventListener=OFF
+# we don't use jTDS
+logging.level.org.geotools.data.sqlserver.jtds=OFF
 
 logging.level.nl.b3p.tailormap.api=TRACE

--- a/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerPostgresIntegrationTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+
+import nl.b3p.tailormap.api.JPAConfiguration;
+import nl.b3p.tailormap.api.security.SecurityConfig;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.RetryingTest;
+import org.junitpioneer.jupiter.Stopwatch;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@SpringBootTest(
+        classes = {JPAConfiguration.class, UniqueValuesController.class, SecurityConfig.class})
+@AutoConfigureMockMvc
+@EnableAutoConfiguration
+@ActiveProfiles("postgresql")
+@Execution(ExecutionMode.CONCURRENT)
+@Stopwatch
+class UniqueValuesControllerPostgresIntegrationTest {
+    private static final String provinciesWFSUrl = "/app/1/layer/2/unique/naam";
+    private static final String begroeidterreindeelPostgisUrl = "/app/1/layer/6/unique/bronhouder";
+    private static final String waterdeelOracleUrl = "/app/1/layer/7/unique/BRONHOUDER";
+    private static final String wegdeelSqlserverUrl = "/app/1/layer/9/unique/bronhouder";
+    @Autowired private MockMvc mockMvc;
+
+    /** layer url + bronhouders. */
+    static Stream<Arguments> databaseArgumentsProvider() {
+        return Stream.of(
+                arguments(
+                        begroeidterreindeelPostgisUrl,
+                        new String[] {
+                            "W0636", "G0344", "L0004", "W0155", "L0001", "P0026", "L0002", "G1904"
+                        }),
+                arguments(
+                        waterdeelOracleUrl,
+                        new String[] {
+                            "W0636", "P0026", "L0002", "W0155", "G1904", "G0344", "L0004"
+                        }),
+                arguments(
+                        wegdeelSqlserverUrl,
+                        new String[] {"P0026", "G0344", "G1904", "L0004", "L0002"}));
+    }
+
+    @ParameterizedTest(name = "#{index}: should return all unique values from database: {0}")
+    @MethodSource("databaseArgumentsProvider")
+    void bronhouder_unique_values_test(String url, String... expected) throws Exception {
+        MvcResult result =
+                mockMvc.perform(
+                                get(url).contentType(MediaType.APPLICATION_JSON)
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.filterApplied").value(false))
+                        .andExpect(jsonPath("$.values").isArray())
+                        .andExpect(jsonPath("$.values").isNotEmpty())
+                        .andReturn();
+
+        final String body = result.getResponse().getContentAsString();
+        List<String> values = JsonPath.read(body, "$.values");
+        final Set<String> uniqueValues = new HashSet<>(values);
+
+        assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
+        assertTrue(uniqueValues.containsAll(Set.of(expected)), "not all values are present");
+    }
+
+    @ParameterizedTest(
+            name =
+                    "#{index}: should return unique bronhouder from database when filtered on bronhouder: {0}")
+    @MethodSource("databaseArgumentsProvider")
+    void bronhouder_with_filter_on_bronhouder_unique_values_test(String url, String... expected)
+            throws Exception {
+        String cqlFilter = "bronhouder='G0344'";
+        if (url.contains("BRONHOUDER")) {
+            // uppercase oracle cql filter
+            cqlFilter = cqlFilter.toUpperCase();
+        }
+
+        MvcResult result =
+                mockMvc.perform(
+                                get(url).param("filter", cqlFilter)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.filterApplied").value(true))
+                        .andExpect(jsonPath("$.values").isArray())
+                        .andExpect(jsonPath("$.values").isNotEmpty())
+                        .andReturn();
+
+        final String body = result.getResponse().getContentAsString();
+        List<String> values = JsonPath.read(body, "$.values");
+
+        assertEquals(1, values.size(), "there should only be 1 value");
+        assertTrue(List.of(expected).contains(values.get(0)), "not all values are present");
+    }
+
+    @ParameterizedTest(
+            name =
+                    "#{index}: should return no unique bronhouder from database with exclusion filter: {0}")
+    @MethodSource("databaseArgumentsProvider")
+    void bronhouder_with_filter_on_inonderzoek_unique_values_test(String url, String... expected)
+            throws Exception {
+        String cqlFilter = "inonderzoek=TRUE";
+        if (url.contains("BRONHOUDER")) {
+            // uppercase oracle cql filter
+            cqlFilter = cqlFilter.toUpperCase();
+        }
+
+        mockMvc.perform(
+                        get(url).param("filter", cqlFilter)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.filterApplied").value(true))
+                .andExpect(jsonPath("$.values").isArray())
+                .andExpect(jsonPath("$.values").isEmpty());
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void broken_filter_returns_bad_request_message() throws Exception {
+        mockMvc.perform(
+                        get(begroeidterreindeelPostgisUrl + "bronhouder")
+                                .param("filter", "naam or Utrecht"))
+                .andExpect(status().is4xxClientError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(
+                        jsonPath("$.message")
+                                .value("Bad Request. Could not parse requested filter."));
+    }
+
+    @RetryingTest(2)
+    void unique_values_from_wfs() throws Exception {
+        MvcResult result =
+                mockMvc.perform(
+                                get(provinciesWFSUrl)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.filterApplied").value(false))
+                        .andExpect(jsonPath("$.values").isArray())
+                        .andExpect(jsonPath("$.values").isNotEmpty())
+                        .andReturn();
+
+        final String body =
+                result.getResponse().getContentAsString(/* for Fryslân */ StandardCharsets.UTF_8);
+        final List<String> values = JsonPath.read(body, "$.values");
+        assertEquals(12, values.size(), "there should be 12 provinces");
+
+        final Set<String> uniqueValues = new HashSet<>(values);
+        assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
+        assertTrue(
+                uniqueValues.containsAll(
+                        Arrays.asList(
+                                "Noord-Brabant",
+                                "Zuid-Holland",
+                                "Utrecht",
+                                "Groningen",
+                                "Drenthe",
+                                "Fryslân",
+                                "Zeeland",
+                                "Limburg",
+                                "Noord-Holland",
+                                "Gelderland",
+                                "Flevoland",
+                                "Overijssel")),
+                "not all values are present");
+    }
+
+    @RetryingTest(2)
+    void unique_values_from_wfs_with_filter_on_same() throws Exception {
+        String cqlFilter = "naam='Utrecht'";
+        mockMvc.perform(
+                        get(provinciesWFSUrl)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .param("filter", cqlFilter))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.filterApplied").value(true))
+                .andExpect(jsonPath("$.values").isArray())
+                .andExpect(jsonPath("$.values.length()").value(1))
+                .andExpect(jsonPath("$.values[0]").value("Utrecht"));
+    }
+
+    @RetryingTest(2)
+    void unique_values_from_wfs_with_filter_on_different() throws Exception {
+        String cqlFilter = "naam like '%Holland'";
+
+        mockMvc.perform(
+                        get(provinciesWFSUrl)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .param("filter", cqlFilter))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.filterApplied").value(true))
+                .andExpect(jsonPath("$.values").isArray())
+                .andExpect(jsonPath("$.values.length()").value(2))
+                .andExpect(jsonPath("$.values[0]").value(Matchers.containsString("-Holland")))
+                .andExpect(jsonPath("$.values[1]").value(Matchers.containsString("-Holland")));
+    }
+}

--- a/src/test/resources/application-postgresql.properties
+++ b/src/test/resources/application-postgresql.properties
@@ -7,13 +7,15 @@ tailormap-api.commitSha=@git.commit.id@
 # whether the api should attempt to provide exact feature counts for all WFS requests
 # may result in double query execution, once for counting and once for the actual data
 tailormap-api.wfs.count.exact=false
+
+tailormap-api.data.useGeotoolsUniqueFunction=true
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 
 # page size for features
 tailormap-api.pageSize=10
 
-#spring.main.banner-mode=console
+spring.main.banner-mode=off
 
 spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/tailormap
 spring.datasource.username=tailormap
@@ -35,12 +37,22 @@ logging.level.org.hibernate=INFO
 #logging.level.org.hibernate.SQL=DEBUG
 #logging.level.org.hibernate.cache=DEBUG
 #logging.level.org.hibernate.stat=DEBUG
+# no hibernate session metrics in the log
+# logging.level.org.hibernate.engine.internal.StatisticalLoggingSessionEventListener=OFF
+
 logging.level.nl.b3p.tailormap.api=TRACE
 
+logging.level.org.geotools=INFO
 #logging.level.org.geotools.http=TRACE
 #logging.level.org.geotools.data=TRACE
 #logging.level.org.geotools.data.ows=TRACE
 #logging.level.org.geotools.data.wfs=TRACE
 #logging.level.org.geotools.wfs=TRACE
+# interfaces and superclasses
+#logging.level.org.geotools.data.jdbc=TRACE
+# specific jdbc implementations, eg. SQL statements
+#logging.level.org.geotools.jdbc=TRACE
+# we don't use jTDS
+logging.level.org.geotools.data.sqlserver.jtds=OFF
 
 spring.main.allow-bean-definition-overriding=true

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -7,12 +7,14 @@ tailormap-api.commitSha=@git.commit.id@
 # whether the api should attempt to provide exact feature counts for all WFS requests
 # may result in double query execution, once for counting and once for the actual data
 tailormap-api.wfs.count.exact=false
+tailormap-api.data.useGeotoolsUniqueFunction=true
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 
 # page size for features
 tailormap-api.pageSize=10
 
+spring.main.banner-mode=off
 # in memory hsqldb (faster, but not possible to inspect database)
 spring.datasource.url=jdbc:hsqldb:mem:unittest-hsqldb-TESTNAMETOKEN/db;DB_CLOSE_DELAY=-1
 # on disk hsqldb


### PR DESCRIPTION
This adds a configuration property `tailormap-api.data.useGeotoolsUniqueFunction` to switch from using SQL "distinct" queries -default/true- to get unique values over to getting all values and process those in memory. The latter may be beneficial for some WFS scenarios.

resolves:

- HTM-457
- HTM-458
- HTM-459
- HTM-473