### PR TITLE
[HTM-430] serialise geometries when configured but skip that by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@ SPDX-License-Identifier: MIT
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <geotools.version>27.1</geotools.version>
+    <jts.version>1.19.0</jts.version>
     <spring.boot.version>${project.parent.version}</spring.boot.version>
     <!--
     Spring-Boot version overrides. see org.springframework.boot:spring-boot-dependencies
@@ -291,8 +292,18 @@ SPDX-License-Identifier: MIT
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+      <version>${jts.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-main</artifactId>
+      <version>${geotools.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-geojson-core</artifactId>
       <version>${geotools.version}</version>
     </dependency>
     <dependency>

--- a/src/main/java/nl/b3p/tailormap/api/controller/FeaturesController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/FeaturesController.java
@@ -83,10 +83,10 @@ import javax.validation.constraints.NotNull;
         path = "/app/{appId}/layer/{appLayerId}/features",
         produces = MediaType.APPLICATION_JSON_VALUE)
 public class FeaturesController implements Constants {
-    @Value("${tailormap-api.pageSize}")
+    @Value("${tailormap-api.pageSize:100}")
     private int pageSize;
 
-    @Value("${tailormap-api.wfs.count.exact}")
+    @Value("${tailormap-api.features.wfs_count_exact:false}")
     private boolean exactWfsCounts;
 
     @Value("${tailormap-api.features.skip_geometry_output:true}")

--- a/src/main/java/nl/b3p/tailormap/api/controller/FeaturesController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/FeaturesController.java
@@ -89,6 +89,9 @@ public class FeaturesController implements Constants {
     @Value("${tailormap-api.wfs.count.exact}")
     private boolean exactWfsCounts;
 
+    @Value("${tailormap-api.features.skip_geometry_output:true}")
+    private boolean skipGeometryOutput;
+
     private final FilterFactory2 ff =
             CommonFactoryFinder.getFilterFactory2(GeoTools.getDefaultHints());
     private final Log logger = LogFactory.getLog(getClass());
@@ -531,10 +534,20 @@ public class FeaturesController implements Constants {
                                 newFeat.putAttributesItem(
                                         configuredAttribute.getAttributeName(), processedGeometry);
                             } else {
-                                newFeat.putAttributesItem(
-                                        configuredAttribute.getAttributeName(),
+                                Object attrValue =
                                         feature.getAttribute(
-                                                configuredAttribute.getAttributeName()));
+                                                configuredAttribute.getAttributeName());
+                                if (attrValue instanceof Geometry) {
+                                    if (skipGeometryOutput) {
+                                        attrValue = null;
+                                    } else {
+                                        attrValue =
+                                                GeometryProcessor.geometryToJson(
+                                                        (Geometry) attrValue);
+                                    }
+                                }
+                                newFeat.putAttributesItem(
+                                        configuredAttribute.getAttributeName(), attrValue);
                             }
                         });
                 featuresResponse.addFeaturesItem(newFeat);

--- a/src/main/java/nl/b3p/tailormap/api/controller/UniqueValuesController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/UniqueValuesController.java
@@ -63,7 +63,7 @@ import javax.persistence.PersistenceContext;
         path = "/app/{appId}/layer/{appLayerId}/unique/{attributeName}",
         produces = MediaType.APPLICATION_JSON_VALUE)
 public class UniqueValuesController {
-    @Value("${tailormap-api.data.useGeotoolsUniqueFunction:true}")
+    @Value("${tailormap-api.unique.use_geotools_unique_function:true}")
     private boolean useGeotoolsUniqueFunction;
 
     private final FilterFactory2 ff =

--- a/src/main/java/nl/b3p/tailormap/api/geotools/processing/GeometryProcessor.java
+++ b/src/main/java/nl/b3p/tailormap/api/geotools/processing/GeometryProcessor.java
@@ -7,6 +7,7 @@ package nl.b3p.tailormap.api.geotools.processing;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.geotools.data.geojson.GeoJSONWriter;
 import org.geotools.geometry.jts.JTS;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.PrecisionModel;
@@ -115,5 +116,9 @@ public final class GeometryProcessor {
         } else {
             return linearizeGeomToWKT(geom);
         }
+    }
+
+    public static String geometryToJson(Geometry geom) {
+        return GeoJSONWriter.toGeoJSON(geom);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,13 +8,15 @@ tailormap-api.commitSha=@git.commit.id@
 tailormap-api.name=@project.artifactId@
 # whether the api should attempt to provide exact feature counts for all WFS requests
 # may result in double query execution, once for counting and once for the actual data
-tailormap-api.wfs.count.exact=false
+tailormap-api.features.wfs_count_exact=false
+# true when to skip geometry while serializing features, does not affect highlight geometry
+tailormap-api.features.skip_geometry_output=true
+
 # whether the API should use GeoTools "Unique Collection" (use DISTINCT in SQL statements) or just retrieve all
 # values when calculating the unique values for a property.
 # There might be a performance difference between the two, depending on the data
-tailormap-api.data.useGeotoolsUniqueFunction=true
-# true when to skip geometry while serializing features, does not affect highlight geometry
-tailormap-api.features.skip_geometry_output=true
+tailormap-api.unique.use_geotools_unique_function=true
+
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,8 @@ tailormap-api.wfs.count.exact=false
 # values when calculating the unique values for a property.
 # There might be a performance difference between the two, depending on the data
 tailormap-api.data.useGeotoolsUniqueFunction=true
+# true when to skip geometry while serializing features, does not affect highlight geometry
+tailormap-api.features.skip_geometry_output=true
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 

--- a/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerPostgresIntegrationTest.java
@@ -68,7 +68,7 @@ class FeaturesControllerPostgresIntegrationTest {
     private static final int wegdeelTotalCount = 5934;
     private final Log logger = LogFactory.getLog(getClass());
 
-    @Value("${tailormap-api.wfs.count.exact}")
+    @Value("${tailormap-api.features.wfs_count_exact:false}")
     private boolean exactWfsCounts;
 
     @Autowired private MockMvc mockMvc;
@@ -986,7 +986,7 @@ class FeaturesControllerPostgresIntegrationTest {
     void filterTest(String applayerUrl, String filterCQL, int totalCount) throws Exception {
         int listSize = Math.min(pageSize, totalCount);
         if (!exactWfsCounts && applayerUrl.equals(provinciesWFS)) {
-            // see #extractWfsCount and property 'tailormap-api.wfs.count.exact'
+            // see #extractWfsCount and property 'tailormap-api.features.wfs_count_exact'
             totalCount = -1;
         }
 

--- a/src/test/java/nl/b3p/tailormap/api/geotools/processing/GeometryProcessorTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/geotools/processing/GeometryProcessorTest.java
@@ -118,4 +118,23 @@ class GeometryProcessorTest extends StaticTestData {
                 GeometryProcessor.processGeometry(ring, false, null),
                 "geometry does not match");
     }
+
+    @Test
+    void testJsonOutput() throws ParseException {
+        Geometry p = new WKTReader2().read(testData.getProperty("RDpointWkt"));
+        assertEquals(
+                "{\"type\":\"Point\",\"coordinates\":[141247,458118]}",
+                GeometryProcessor.geometryToJson(p),
+                "json output should match");
+
+        // this is ignored by the json output
+        p.setSRID(28992);
+        assertEquals(
+                "{\"type\":\"Point\",\"coordinates\":[141247,458118]}",
+                GeometryProcessor.geometryToJson(p),
+                "json output should match");
+
+        p = null;
+        assertEquals("null", GeometryProcessor.geometryToJson(p), "json output should match");
+    }
 }

--- a/src/test/resources/application-postgresql.properties
+++ b/src/test/resources/application-postgresql.properties
@@ -4,11 +4,7 @@ tailormap-api.version=@project.version@
 tailormap-api.apiVersion=@info.version@
 # commit sha
 tailormap-api.commitSha=@git.commit.id@
-# whether the api should attempt to provide exact feature counts for all WFS requests
-# may result in double query execution, once for counting and once for the actual data
-tailormap-api.wfs.count.exact=false
 
-tailormap-api.data.useGeotoolsUniqueFunction=true
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -4,10 +4,7 @@ tailormap-api.version=@project.version@
 tailormap-api.apiVersion=@info.version@
 # commit sha
 tailormap-api.commitSha=@git.commit.id@
-# whether the api should attempt to provide exact feature counts for all WFS requests
-# may result in double query execution, once for counting and once for the actual data
-tailormap-api.wfs.count.exact=false
-tailormap-api.data.useGeotoolsUniqueFunction=true
+
 # base url
 server.servlet.context-path=@servers.variables.basePath.default@
 


### PR DESCRIPTION
Solve the user/admin error of configuring a geometry attribute for display.

- define a configuration property to skip geometry output with features (default `true`)
- output geometry as geojson using GeoTools serializer (JTS was unusable due to conflicting, ancient json dependency)
- also refactored config properties to follow endpoint names



resolves HTM-430