### PR TITLE
Bump `hibernate.version` from 5.6.11.Final to 5.6.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ SPDX-License-Identifier: MIT
     <!--    <jackson-bom.version>2.13.4</jackson-bom.version>-->
     <!--    <micrometer.version>1.9.4</micrometer.version>-->
     <!-- make sure to keep this hibernate version and that of tailormap persistence version in sync -->
-    <hibernate.version>5.6.11.Final</hibernate.version>
+    <hibernate.version>5.6.12.Final</hibernate.version>
     <hsqldb.version>2.7.0</hsqldb.version>
     <junit-jupiter.version>5.9.1</junit-jupiter.version>
     <mssql-jdbc.version>11.2.1.jre11</mssql-jdbc.version>


### PR DESCRIPTION
Bumps `hibernate.version` from 5.6.11.Final to 5.6.12.Final.

Updates `hibernate-core` from 5.6.11.Final to 5.6.12.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/5.6.12/changelog.txt)
- [Commits](hibernate/hibernate-orm@5.6.11...5.6.12)

Updates `hibernate-entitymanager` from 5.6.11.Final to 5.6.12.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/5.6.12/changelog.txt)
- [Commits](hibernate/hibernate-orm@5.6.11...5.6.12)

see also https://github.com/B3Partners/tailormap-persistence/pull/38