### PR TITLE
Upgrade the expat library to 2.4.9-r0 to resolve CVE-2022-40674

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ LABEL org.opencontainers.image.authors="support@b3partners.nl" \
 
 # set-up timezone and local user
 RUN set -eux;ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
-    && addgroup -S spring && adduser -S spring -G spring
+    && addgroup -S spring && adduser -S spring -G spring \
+    # for CVE-2022-40674, this can probably be removed when we upgrade the base image > eclipse-temurin:11.0.16.1_1-jre-alpine
+    && apk add --no-cache expat=2.4.9-r0
 
 USER spring:spring
 

--- a/build/qa/owasp-suppression.xml
+++ b/build/qa/owasp-suppression.xml
@@ -19,4 +19,11 @@ SPDX-License-Identifier: MIT
         <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
         <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: snakeyaml-1.33.jar, fixed in 1.32
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <vulnerabilityName>CVE-2022-38752</vulnerabilityName>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
see https://github.com/B3Partners/tailormap-api/security/code-scanning/64