### PR TITLE
[HTM-492] Getting unique values for a timestamp on oracle database gives a 500 error

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/nl/b3p/tailormap/api/configuration/dev/PopulateTestData.java
@@ -321,7 +321,7 @@ public class PopulateTestData {
                     new JDBCConnectionProperties()
                         .dbtype(JDBCConnectionProperties.DbtypeEnum.ORACLE)
                         .host(connectToSpatialDbsAtLocalhost ? "127.0.0.1" : "oracle")
-                        .database("/XEPDB1")
+                        .database("/XEPDB1?oracle.jdbc.J2EE13Compliant=true")
                         .schema("GEODATA"))
                 .setAuthentication(
                     new ServiceAuthentication()

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -14,3 +14,6 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 #logging.level.org.springframework.boot=DEBUG
 #logging.level.org.springframework.boot.autoconfigure=DEBUG
 #logging.level.org.springframework.test.context=DEBUG
+
+# log all GeoTools SQL queries
+logging.level.org.geotools.jdbc=DEBUG

--- a/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerPostgresIntegrationTest.java
@@ -279,4 +279,34 @@ class UniqueValuesControllerPostgresIntegrationTest {
         .andExpect(jsonPath("$.values[0]").value(Matchers.containsString("-Holland")))
         .andExpect(jsonPath("$.values[1]").value(Matchers.containsString("-Holland")));
   }
+
+  /**
+   * Testcase for <a href="https://b3partners.atlassian.net/browse/HTM-492">HTM-492</a> where Jakson
+   * fails to process oracle.sql.TIMESTAMP.
+   *
+   * <p>The exception is: {@code org.springframework.web.util.NestedServletException: Request
+   * processing failed; nested exception is
+   * org.springframework.http.converter.HttpMessageConversionException: Type definition error:
+   * [simple type, class java.io.ByteArrayInputStream]; nested exception is
+   * com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class
+   * java.io.ByteArrayInputStream and no properties discovered to create BeanSerializer (to avoid
+   * exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain:
+   * nl.b3p.tailormap.api.model.UniqueValuesResponse["values"]->java.util.HashSet[0]->oracle.sql.TIMESTAMP["stream"])
+   * }
+   *
+   * @throws Exception if any
+   */
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void unique_values_oracle_timestamp_HTM_492() throws Exception {
+    final String testUrl = "/app/1/layer/7/unique/TIJDSTIPREGISTRATIE";
+    mockMvc
+        .perform(
+            get(testUrl).contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.filterApplied").value(true))
+        .andExpect(jsonPath("$.values").isArray())
+        .andExpect(jsonPath("$.values").isNotEmpty());
+  }
 }

--- a/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerPostgresIntegrationTest.java
@@ -293,7 +293,11 @@ class UniqueValuesControllerPostgresIntegrationTest {
    * }
    *
    * <p>For this testcase to go green set the environment variable {@code -Doracle.jdbc.J2EE13Compliant=true}
-   * <p>See also: <a href="https://stackoverflow.com/questions/13269564/java-lang-classcastexception-oracle-sql-timestamp-cannot-be-cast-to-java-sql-ti">java.lang.ClassCastException: oracle.sql.TIMESTAMP cannot be cast to java.sql.Timestamp</a>
+   * <p>See also:
+   * <ul>
+   *     <li><a href="https://stackoverflow.com/questions/13269564/java-lang-classcastexception-oracle-sql-timestamp-cannot-be-cast-to-java-sql-ti">java.lang.ClassCastException: oracle.sql.TIMESTAMP cannot be cast to java.sql.Timestamp</a></li>
+   *     <li><a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/accessing-and-manipulating-Oracle-data.html#GUID-C23007CA-E25D-4747-A3C0-4DE219AF56BD">Accessing and Manipulating Oracle Data</a></li>
+   * </ul>
    *
    * @throws Exception if any
    */

--- a/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerPostgresIntegrationTest.java
@@ -282,21 +282,26 @@ class UniqueValuesControllerPostgresIntegrationTest {
   }
 
   /**
-   * Testcase for <a href="https://b3partners.atlassian.net/browse/HTM-492">HTM-492</a> where Jackson
-   * fails to process oracle.sql.TIMESTAMP.
+   * Testcase for <a href="https://b3partners.atlassian.net/browse/HTM-492">HTM-492</a> where
+   * Jackson fails to process oracle.sql.TIMESTAMP.
    *
-   * <p>The exception is: {@code org.springframework.web.util.NestedServletException:
-   * Request processing failed; nested exception is java.lang.ClassCastException:
-   * class oracle.sql.TIMESTAMP cannot be cast to class java.lang.Comparable
-   * (oracle.sql.TIMESTAMP is in unnamed module of loader 'app';
-   * java.lang.Comparable is in module java.base of loader 'bootstrap')
-   * }
+   * <p>The exception is: {@code org.springframework.web.util.NestedServletException: Request
+   * processing failed; nested exception is java.lang.ClassCastException: class oracle.sql.TIMESTAMP
+   * cannot be cast to class java.lang.Comparable (oracle.sql.TIMESTAMP is in unnamed module of
+   * loader 'app'; java.lang.Comparable is in module java.base of loader 'bootstrap') }
    *
-   * <p>For this testcase to go green set the environment variable {@code -Doracle.jdbc.J2EE13Compliant=true}
+   * <p>For this testcase to go green set the environment variable {@code
+   * -Doracle.jdbc.J2EE13Compliant=true}
+   *
    * <p>See also:
+   *
    * <ul>
-   *     <li><a href="https://stackoverflow.com/questions/13269564/java-lang-classcastexception-oracle-sql-timestamp-cannot-be-cast-to-java-sql-ti">java.lang.ClassCastException: oracle.sql.TIMESTAMP cannot be cast to java.sql.Timestamp</a></li>
-   *     <li><a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/accessing-and-manipulating-Oracle-data.html#GUID-C23007CA-E25D-4747-A3C0-4DE219AF56BD">Accessing and Manipulating Oracle Data</a></li>
+   *   <li><a
+   *       href="https://stackoverflow.com/questions/13269564/java-lang-classcastexception-oracle-sql-timestamp-cannot-be-cast-to-java-sql-ti">java.lang.ClassCastException:
+   *       oracle.sql.TIMESTAMP cannot be cast to java.sql.Timestamp</a>
+   *   <li><a
+   *       href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/accessing-and-manipulating-Oracle-data.html#GUID-C23007CA-E25D-4747-A3C0-4DE219AF56BD">Accessing
+   *       and Manipulating Oracle Data</a>
    * </ul>
    *
    * @throws Exception if any
@@ -305,15 +310,16 @@ class UniqueValuesControllerPostgresIntegrationTest {
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void unique_values_oracle_timestamp_HTM_492() throws Exception {
-    final String testUrl = apiBasePath +
-            "/app/default/layer/lyr:snapshot-geoserver:oracle:WATERDEEL/unique/TIJDSTIPREGISTRATIE";
+    final String testUrl =
+        apiBasePath
+            + "/app/default/layer/lyr:snapshot-geoserver:oracle:WATERDEEL/unique/TIJDSTIPREGISTRATIE";
     mockMvc
-            .perform(
-                    get(testUrl).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(testUrl)))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.filterApplied").value(false))
-            .andExpect(jsonPath("$.values").isArray())
-            .andExpect(jsonPath("$.values").isNotEmpty());
+        .perform(
+            get(testUrl).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(testUrl)))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.filterApplied").value(false))
+        .andExpect(jsonPath("$.values").isArray())
+        .andExpect(jsonPath("$.values").isNotEmpty());
   }
 }

--- a/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerReConfiguredPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerReConfiguredPostgresIntegrationTest.java
@@ -48,13 +48,14 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 @TestPropertySource(properties = {"tailormap-api.unique.use_geotools_unique_function=false"})
 class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
   private static final String provinciesWFSUrl =
-          "/app/default/layer/lyr:pdok-kadaster-bestuurlijkegebieden:Provinciegebied/unique/naam";
+      "/app/default/layer/lyr:pdok-kadaster-bestuurlijkegebieden:Provinciegebied/unique/naam";
   private static final String begroeidterreindeelPostgisUrl =
-          "/app/default/layer/lyr:snapshot-geoserver:postgis:begroeidterreindeel/unique/bronhouder";
+      "/app/default/layer/lyr:snapshot-geoserver:postgis:begroeidterreindeel/unique/bronhouder";
   private static final String waterdeelOracleUrl =
-          "/app/default/layer/lyr:snapshot-geoserver:oracle:WATERDEEL/unique/BRONHOUDER";
+      "/app/default/layer/lyr:snapshot-geoserver:oracle:WATERDEEL/unique/BRONHOUDER";
   private static final String wegdeelSqlserverUrl =
-          "/app/default/layer/lyr:snapshot-geoserver:sqlserver:wegdeel/unique/bronhouder";
+      "/app/default/layer/lyr:snapshot-geoserver:sqlserver:wegdeel/unique/bronhouder";
+
   @Value("${tailormap-api.base-path}")
   private String apiBasePath;
 
@@ -83,14 +84,14 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
   void bronhouder_unique_values_test(String url, String... expected) throws Exception {
     url = apiBasePath + url;
     MvcResult result =
-            mockMvc
-                    .perform(get(url).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(url)))
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.filterApplied").value(false))
-                    .andExpect(jsonPath("$.values").isArray())
-                    .andExpect(jsonPath("$.values").isNotEmpty())
-                    .andReturn();
+        mockMvc
+            .perform(get(url).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(url)))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.filterApplied").value(false))
+            .andExpect(jsonPath("$.values").isArray())
+            .andExpect(jsonPath("$.values").isNotEmpty())
+            .andReturn();
 
     final String body = result.getResponse().getContentAsString();
     List<String> values = JsonPath.read(body, "$.values");
@@ -101,11 +102,11 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
   }
 
   @ParameterizedTest(
-          name =
-                  "#{index}: should return unique bronhouder from database when filtered on bronhouder: {0}")
+      name =
+          "#{index}: should return unique bronhouder from database when filtered on bronhouder: {0}")
   @MethodSource("databaseArgumentsProvider")
   void bronhouder_with_filter_on_bronhouder_unique_values_test(String url, String... expected)
-          throws Exception {
+      throws Exception {
     url = apiBasePath + url;
     String cqlFilter = "bronhouder='G0344'";
     if (url.contains("BRONHOUDER")) {
@@ -114,18 +115,18 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
     }
 
     MvcResult result =
-            mockMvc
-                    .perform(
-                            get(url)
-                                    .accept(MediaType.APPLICATION_JSON)
-                                    .with(requestPostProcessor(url))
-                                    .param("filter", cqlFilter))
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.filterApplied").value(true))
-                    .andExpect(jsonPath("$.values").isArray())
-                    .andExpect(jsonPath("$.values").isNotEmpty())
-                    .andReturn();
+        mockMvc
+            .perform(
+                get(url)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .with(requestPostProcessor(url))
+                    .param("filter", cqlFilter))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.filterApplied").value(true))
+            .andExpect(jsonPath("$.values").isArray())
+            .andExpect(jsonPath("$.values").isNotEmpty())
+            .andReturn();
 
     final String body = result.getResponse().getContentAsString();
     List<String> values = JsonPath.read(body, "$.values");
@@ -135,8 +136,8 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
   }
 
   @ParameterizedTest(
-          name =
-                  "#{index}: should return no unique bronhouder from database with exclusion filter: {0}")
+      name =
+          "#{index}: should return no unique bronhouder from database with exclusion filter: {0}")
   @MethodSource("databaseArgumentsProvider")
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void bronhouder_with_filter_on_inonderzoek_unique_values_test(String url) throws Exception {
@@ -148,16 +149,16 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
     }
 
     mockMvc
-            .perform(
-                    get(url)
-                            .with(requestPostProcessor(url))
-                            .param("filter", cqlFilter)
-                            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.filterApplied").value(true))
-            .andExpect(jsonPath("$.values").isArray())
-            .andExpect(jsonPath("$.values").isEmpty());
+        .perform(
+            get(url)
+                .with(requestPostProcessor(url))
+                .param("filter", cqlFilter)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.filterApplied").value(true))
+        .andExpect(jsonPath("$.values").isArray())
+        .andExpect(jsonPath("$.values").isEmpty());
   }
 
   @Test
@@ -165,55 +166,54 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
   void broken_filter_returns_bad_request_message() throws Exception {
     final String url = apiBasePath + begroeidterreindeelPostgisUrl + "bronhouder";
     mockMvc
-            .perform(
-                    get(url)
-                            .param("filter", "naam or Utrecht")
-                            .accept(MediaType.APPLICATION_JSON)
-                            .with(requestPostProcessor(url)))
-            .andExpect(status().is4xxClientError())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.code").value(400))
-            .andExpect(jsonPath("$.message").value("Could not parse requested filter"));
+        .perform(
+            get(url)
+                .param("filter", "naam or Utrecht")
+                .accept(MediaType.APPLICATION_JSON)
+                .with(requestPostProcessor(url)))
+        .andExpect(status().is4xxClientError())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.message").value("Could not parse requested filter"));
   }
 
-
   @RetryingTest(2)
-    // https://b3partners.atlassian.net/browse/HTM-758
+  // https://b3partners.atlassian.net/browse/HTM-758
   void unique_values_from_wfs() throws Exception {
     final String url = apiBasePath + provinciesWFSUrl;
     MvcResult result =
-            mockMvc
-                    .perform(get(url).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(url)))
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.filterApplied").value(false))
-                    .andExpect(jsonPath("$.values").isArray())
-                    .andExpect(jsonPath("$.values").isNotEmpty())
-                    .andReturn();
+        mockMvc
+            .perform(get(url).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(url)))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.filterApplied").value(false))
+            .andExpect(jsonPath("$.values").isArray())
+            .andExpect(jsonPath("$.values").isNotEmpty())
+            .andReturn();
 
     final String body =
-            result.getResponse().getContentAsString(/* for Fryslân */ StandardCharsets.UTF_8);
+        result.getResponse().getContentAsString(/* for Fryslân */ StandardCharsets.UTF_8);
     final List<String> values = JsonPath.read(body, "$.values");
     assertEquals(12, values.size(), "there should be 12 provinces");
 
     final Set<String> uniqueValues = new HashSet<>(values);
     assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
     assertTrue(
-            uniqueValues.containsAll(
-                    Arrays.asList(
-                            "Noord-Brabant",
-                            "Zuid-Holland",
-                            "Utrecht",
-                            "Groningen",
-                            "Drenthe",
-                            "Fryslân",
-                            "Zeeland",
-                            "Limburg",
-                            "Noord-Holland",
-                            "Gelderland",
-                            "Flevoland",
-                            "Overijssel")),
-            "not all values are present");
+        uniqueValues.containsAll(
+            Arrays.asList(
+                "Noord-Brabant",
+                "Zuid-Holland",
+                "Utrecht",
+                "Groningen",
+                "Drenthe",
+                "Fryslân",
+                "Zeeland",
+                "Limburg",
+                "Noord-Holland",
+                "Gelderland",
+                "Flevoland",
+                "Overijssel")),
+        "not all values are present");
 
     final List<String> sortedValues = values.stream().sorted().collect(Collectors.toList());
     assertEquals(sortedValues, values, "Unique values should be sorted");
@@ -224,17 +224,17 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
     final String url = apiBasePath + provinciesWFSUrl;
     final String cqlFilter = "naam='Utrecht'";
     mockMvc
-            .perform(
-                    get(url)
-                            .accept(MediaType.APPLICATION_JSON)
-                            .with(requestPostProcessor(url))
-                            .param("filter", cqlFilter))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.filterApplied").value(true))
-            .andExpect(jsonPath("$.values").isArray())
-            .andExpect(jsonPath("$.values.length()").value(1))
-            .andExpect(jsonPath("$.values[0]").value("Utrecht"));
+        .perform(
+            get(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(requestPostProcessor(url))
+                .param("filter", cqlFilter))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.filterApplied").value(true))
+        .andExpect(jsonPath("$.values").isArray())
+        .andExpect(jsonPath("$.values.length()").value(1))
+        .andExpect(jsonPath("$.values[0]").value("Utrecht"));
   }
 
   @RetryingTest(2)
@@ -242,33 +242,34 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
     String cqlFilter = "naam like '%Holland'";
     final String url = apiBasePath + provinciesWFSUrl;
     mockMvc
-            .perform(
-                    get(url)
-                            .accept(MediaType.APPLICATION_JSON)
-                            .with(requestPostProcessor(url))
-                            .param("filter", cqlFilter))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.filterApplied").value(true))
-            .andExpect(jsonPath("$.values").isArray())
-            .andExpect(jsonPath("$.values.length()").value(2))
-            .andExpect(jsonPath("$.values[0]").value(Matchers.containsString("-Holland")))
-            .andExpect(jsonPath("$.values[1]").value(Matchers.containsString("-Holland")));
+        .perform(
+            get(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(requestPostProcessor(url))
+                .param("filter", cqlFilter))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.filterApplied").value(true))
+        .andExpect(jsonPath("$.values").isArray())
+        .andExpect(jsonPath("$.values.length()").value(2))
+        .andExpect(jsonPath("$.values[0]").value(Matchers.containsString("-Holland")))
+        .andExpect(jsonPath("$.values[1]").value(Matchers.containsString("-Holland")));
   }
 
   @Issue("https://b3partners.atlassian.net/browse/HTM-492")
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void unique_values_oracle_timestamp_HTM_492() throws Exception {
-    final String testUrl = apiBasePath +
-        "/app/default/layer/lyr:snapshot-geoserver:oracle:WATERDEEL/unique/TIJDSTIPREGISTRATIE";
+    final String testUrl =
+        apiBasePath
+            + "/app/default/layer/lyr:snapshot-geoserver:oracle:WATERDEEL/unique/TIJDSTIPREGISTRATIE";
     mockMvc
-            .perform(
-                    get(testUrl).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(testUrl)))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.filterApplied").value(false))
-            .andExpect(jsonPath("$.values").isArray())
-            .andExpect(jsonPath("$.values").isNotEmpty());
+        .perform(
+            get(testUrl).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(testUrl)))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.filterApplied").value(false))
+        .andExpect(jsonPath("$.values").isArray())
+        .andExpect(jsonPath("$.values").isNotEmpty());
   }
 }

--- a/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerReConfiguredPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerReConfiguredPostgresIntegrationTest.java
@@ -19,10 +19,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import nl.b3p.tailormap.api.JPAConfiguration;
-import nl.b3p.tailormap.api.security.AuthorizationService;
-import nl.b3p.tailormap.api.security.SecurityConfig;
+import nl.b3p.tailormap.api.annotation.PostgresIntegrationTest;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -30,38 +29,43 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.Issue;
 import org.junitpioneer.jupiter.RetryingTest;
 import org.junitpioneer.jupiter.Stopwatch;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
-@SpringBootTest(
-    classes = {
-      JPAConfiguration.class,
-      UniqueValuesController.class,
-      SecurityConfig.class,
-      AuthorizationService.class
-    })
+@PostgresIntegrationTest
 @AutoConfigureMockMvc
-@EnableAutoConfiguration
-@ActiveProfiles("postgresql")
 @Execution(ExecutionMode.CONCURRENT)
 @Stopwatch
 @TestPropertySource(properties = {"tailormap-api.unique.use_geotools_unique_function=false"})
 class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
-  private static final String provinciesWFSUrl = "/app/1/layer/2/unique/naam";
-  private static final String begroeidterreindeelPostgisUrl = "/app/1/layer/6/unique/bronhouder";
-  private static final String waterdeelOracleUrl = "/app/1/layer/7/unique/BRONHOUDER";
-  private static final String wegdeelSqlserverUrl = "/app/1/layer/9/unique/bronhouder";
+  private static final String provinciesWFSUrl =
+          "/app/default/layer/lyr:pdok-kadaster-bestuurlijkegebieden:Provinciegebied/unique/naam";
+  private static final String begroeidterreindeelPostgisUrl =
+          "/app/default/layer/lyr:snapshot-geoserver:postgis:begroeidterreindeel/unique/bronhouder";
+  private static final String waterdeelOracleUrl =
+          "/app/default/layer/lyr:snapshot-geoserver:oracle:WATERDEEL/unique/BRONHOUDER";
+  private static final String wegdeelSqlserverUrl =
+          "/app/default/layer/lyr:snapshot-geoserver:sqlserver:wegdeel/unique/bronhouder";
+  @Value("${tailormap-api.base-path}")
+  private String apiBasePath;
+
   @Autowired private MockMvc mockMvc;
 
+  private static RequestPostProcessor requestPostProcessor(String servletPath) {
+    return request -> {
+      request.setServletPath(servletPath);
+      return request;
+    };
+  }
   /** layer url + bronhouders. */
   static Stream<Arguments> databaseArgumentsProvider() {
     return Stream.of(
@@ -77,16 +81,16 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
   @ParameterizedTest(name = "#{index}: should return all unique values from database: {0}")
   @MethodSource("databaseArgumentsProvider")
   void bronhouder_unique_values_test(String url, String... expected) throws Exception {
+    url = apiBasePath + url;
     MvcResult result =
-        mockMvc
-            .perform(
-                get(url).contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.filterApplied").value(false))
-            .andExpect(jsonPath("$.values").isArray())
-            .andExpect(jsonPath("$.values").isNotEmpty())
-            .andReturn();
+            mockMvc
+                    .perform(get(url).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(url)))
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.filterApplied").value(false))
+                    .andExpect(jsonPath("$.values").isArray())
+                    .andExpect(jsonPath("$.values").isNotEmpty())
+                    .andReturn();
 
     final String body = result.getResponse().getContentAsString();
     List<String> values = JsonPath.read(body, "$.values");
@@ -97,11 +101,12 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
   }
 
   @ParameterizedTest(
-      name =
-          "#{index}: should return unique bronhouder from database when filtered on bronhouder: {0}")
+          name =
+                  "#{index}: should return unique bronhouder from database when filtered on bronhouder: {0}")
   @MethodSource("databaseArgumentsProvider")
   void bronhouder_with_filter_on_bronhouder_unique_values_test(String url, String... expected)
-      throws Exception {
+          throws Exception {
+    url = apiBasePath + url;
     String cqlFilter = "bronhouder='G0344'";
     if (url.contains("BRONHOUDER")) {
       // uppercase oracle cql filter
@@ -109,18 +114,18 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
     }
 
     MvcResult result =
-        mockMvc
-            .perform(
-                get(url)
-                    .param("filter", cqlFilter)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.filterApplied").value(true))
-            .andExpect(jsonPath("$.values").isArray())
-            .andExpect(jsonPath("$.values").isNotEmpty())
-            .andReturn();
+            mockMvc
+                    .perform(
+                            get(url)
+                                    .accept(MediaType.APPLICATION_JSON)
+                                    .with(requestPostProcessor(url))
+                                    .param("filter", cqlFilter))
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.filterApplied").value(true))
+                    .andExpect(jsonPath("$.values").isArray())
+                    .andExpect(jsonPath("$.values").isNotEmpty())
+                    .andReturn();
 
     final String body = result.getResponse().getContentAsString();
     List<String> values = JsonPath.read(body, "$.values");
@@ -130,11 +135,12 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
   }
 
   @ParameterizedTest(
-      name =
-          "#{index}: should return no unique bronhouder from database with exclusion filter: {0}")
+          name =
+                  "#{index}: should return no unique bronhouder from database with exclusion filter: {0}")
   @MethodSource("databaseArgumentsProvider")
-  void bronhouder_with_filter_on_inonderzoek_unique_values_test(String url, String... expected)
-      throws Exception {
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void bronhouder_with_filter_on_inonderzoek_unique_values_test(String url) throws Exception {
+    url = apiBasePath + url;
     String cqlFilter = "inonderzoek=TRUE";
     if (url.contains("BRONHOUDER")) {
       // uppercase oracle cql filter
@@ -142,133 +148,127 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
     }
 
     mockMvc
-        .perform(
-            get(url)
-                .param("filter", cqlFilter)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.filterApplied").value(true))
-        .andExpect(jsonPath("$.values").isArray())
-        .andExpect(jsonPath("$.values").isEmpty());
+            .perform(
+                    get(url)
+                            .with(requestPostProcessor(url))
+                            .param("filter", cqlFilter)
+                            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.filterApplied").value(true))
+            .andExpect(jsonPath("$.values").isArray())
+            .andExpect(jsonPath("$.values").isEmpty());
   }
 
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void broken_filter_returns_bad_request_message() throws Exception {
+    final String url = apiBasePath + begroeidterreindeelPostgisUrl + "bronhouder";
     mockMvc
-        .perform(
-            get(begroeidterreindeelPostgisUrl + "bronhouder").param("filter", "naam or Utrecht"))
-        .andExpect(status().is4xxClientError())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.code").value(400))
-        .andExpect(jsonPath("$.message").value("Bad Request. Could not parse requested filter."));
+            .perform(
+                    get(url)
+                            .param("filter", "naam or Utrecht")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(requestPostProcessor(url)))
+            .andExpect(status().is4xxClientError())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.code").value(400))
+            .andExpect(jsonPath("$.message").value("Could not parse requested filter"));
   }
 
+
   @RetryingTest(2)
+    // https://b3partners.atlassian.net/browse/HTM-758
   void unique_values_from_wfs() throws Exception {
+    final String url = apiBasePath + provinciesWFSUrl;
     MvcResult result =
-        mockMvc
-            .perform(
-                get(provinciesWFSUrl)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON))
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.filterApplied").value(false))
-            .andExpect(jsonPath("$.values").isArray())
-            .andExpect(jsonPath("$.values").isNotEmpty())
-            .andReturn();
+            mockMvc
+                    .perform(get(url).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(url)))
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.filterApplied").value(false))
+                    .andExpect(jsonPath("$.values").isArray())
+                    .andExpect(jsonPath("$.values").isNotEmpty())
+                    .andReturn();
 
     final String body =
-        result.getResponse().getContentAsString(/* for Fryslân */ StandardCharsets.UTF_8);
+            result.getResponse().getContentAsString(/* for Fryslân */ StandardCharsets.UTF_8);
     final List<String> values = JsonPath.read(body, "$.values");
     assertEquals(12, values.size(), "there should be 12 provinces");
 
     final Set<String> uniqueValues = new HashSet<>(values);
     assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
     assertTrue(
-        uniqueValues.containsAll(
-            Arrays.asList(
-                "Noord-Brabant",
-                "Zuid-Holland",
-                "Utrecht",
-                "Groningen",
-                "Drenthe",
-                "Fryslân",
-                "Zeeland",
-                "Limburg",
-                "Noord-Holland",
-                "Gelderland",
-                "Flevoland",
-                "Overijssel")),
-        "not all values are present");
+            uniqueValues.containsAll(
+                    Arrays.asList(
+                            "Noord-Brabant",
+                            "Zuid-Holland",
+                            "Utrecht",
+                            "Groningen",
+                            "Drenthe",
+                            "Fryslân",
+                            "Zeeland",
+                            "Limburg",
+                            "Noord-Holland",
+                            "Gelderland",
+                            "Flevoland",
+                            "Overijssel")),
+            "not all values are present");
+
+    final List<String> sortedValues = values.stream().sorted().collect(Collectors.toList());
+    assertEquals(sortedValues, values, "Unique values should be sorted");
   }
 
   @RetryingTest(2)
   void unique_values_from_wfs_with_filter_on_same() throws Exception {
-    String cqlFilter = "naam='Utrecht'";
+    final String url = apiBasePath + provinciesWFSUrl;
+    final String cqlFilter = "naam='Utrecht'";
     mockMvc
-        .perform(
-            get(provinciesWFSUrl)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON)
-                .param("filter", cqlFilter))
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.filterApplied").value(true))
-        .andExpect(jsonPath("$.values").isArray())
-        .andExpect(jsonPath("$.values.length()").value(1))
-        .andExpect(jsonPath("$.values[0]").value("Utrecht"));
+            .perform(
+                    get(url)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(requestPostProcessor(url))
+                            .param("filter", cqlFilter))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.filterApplied").value(true))
+            .andExpect(jsonPath("$.values").isArray())
+            .andExpect(jsonPath("$.values.length()").value(1))
+            .andExpect(jsonPath("$.values[0]").value("Utrecht"));
   }
 
   @RetryingTest(2)
   void unique_values_from_wfs_with_filter_on_different() throws Exception {
     String cqlFilter = "naam like '%Holland'";
-
+    final String url = apiBasePath + provinciesWFSUrl;
     mockMvc
-        .perform(
-            get(provinciesWFSUrl)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON)
-                .param("filter", cqlFilter))
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.filterApplied").value(true))
-        .andExpect(jsonPath("$.values").isArray())
-        .andExpect(jsonPath("$.values.length()").value(2))
-        .andExpect(jsonPath("$.values[0]").value(Matchers.containsString("-Holland")))
-        .andExpect(jsonPath("$.values[1]").value(Matchers.containsString("-Holland")));
+            .perform(
+                    get(url)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(requestPostProcessor(url))
+                            .param("filter", cqlFilter))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.filterApplied").value(true))
+            .andExpect(jsonPath("$.values").isArray())
+            .andExpect(jsonPath("$.values.length()").value(2))
+            .andExpect(jsonPath("$.values[0]").value(Matchers.containsString("-Holland")))
+            .andExpect(jsonPath("$.values[1]").value(Matchers.containsString("-Holland")));
   }
 
-  /**
-   * Testcase for <a href="https://b3partners.atlassian.net/browse/HTM-492">HTM-492</a> where Jakson
-   * fails to process oracle.sql.TIMESTAMP.
-   *
-   * <p>The exception is: {@code org.springframework.web.util.NestedServletException: Request
-   * processing failed; nested exception is
-   * org.springframework.http.converter.HttpMessageConversionException: Type definition error:
-   * [simple type, class java.io.ByteArrayInputStream]; nested exception is
-   * com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class
-   * java.io.ByteArrayInputStream and no properties discovered to create BeanSerializer (to avoid
-   * exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain:
-   * nl.b3p.tailormap.api.model.UniqueValuesResponse["values"]->java.util.HashSet[0]->oracle.sql.TIMESTAMP["stream"])
-   * }
-   *
-   * @throws Exception if any
-   */
+  @Issue("https://b3partners.atlassian.net/browse/HTM-492")
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void unique_values_oracle_timestamp_HTM_492() throws Exception {
-    final String testUrl = "/app/1/layer/7/unique/TIJDSTIPREGISTRATIE";
+    final String testUrl = apiBasePath +
+        "/app/default/layer/lyr:snapshot-geoserver:oracle:WATERDEEL/unique/TIJDSTIPREGISTRATIE";
     mockMvc
-        .perform(
-            get(testUrl).contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.filterApplied").value(false))
-        .andExpect(jsonPath("$.values").isArray())
-        .andExpect(jsonPath("$.values").isNotEmpty());
+            .perform(
+                    get(testUrl).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(testUrl)))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.filterApplied").value(false))
+            .andExpect(jsonPath("$.values").isArray())
+            .andExpect(jsonPath("$.values").isNotEmpty());
   }
 }

--- a/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerReConfiguredPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerReConfiguredPostgresIntegrationTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+
+import nl.b3p.tailormap.api.JPAConfiguration;
+import nl.b3p.tailormap.api.security.AuthorizationService;
+import nl.b3p.tailormap.api.security.SecurityConfig;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.RetryingTest;
+import org.junitpioneer.jupiter.Stopwatch;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@SpringBootTest(
+        classes = {
+            JPAConfiguration.class,
+            UniqueValuesController.class,
+            SecurityConfig.class,
+            AuthorizationService.class
+        })
+@AutoConfigureMockMvc
+@EnableAutoConfiguration
+@ActiveProfiles("postgresql")
+@Execution(ExecutionMode.CONCURRENT)
+@Stopwatch
+@TestPropertySource(properties = {"tailormap-api.unique.use_geotools_unique_function=false"})
+class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
+    private static final String provinciesWFSUrl = "/app/1/layer/2/unique/naam";
+    private static final String begroeidterreindeelPostgisUrl = "/app/1/layer/6/unique/bronhouder";
+    private static final String waterdeelOracleUrl = "/app/1/layer/7/unique/BRONHOUDER";
+    private static final String wegdeelSqlserverUrl = "/app/1/layer/9/unique/bronhouder";
+    @Autowired private MockMvc mockMvc;
+
+    /** layer url + bronhouders. */
+    static Stream<Arguments> databaseArgumentsProvider() {
+        return Stream.of(
+                arguments(
+                        begroeidterreindeelPostgisUrl,
+                        new String[] {
+                            "W0636", "G0344", "L0004", "W0155", "L0001", "P0026", "L0002", "G1904"
+                        }),
+                arguments(
+                        waterdeelOracleUrl,
+                        new String[] {
+                            "W0636", "P0026", "L0002", "W0155", "G1904", "G0344", "L0004"
+                        }),
+                arguments(
+                        wegdeelSqlserverUrl,
+                        new String[] {"P0026", "G0344", "G1904", "L0004", "L0002"}));
+    }
+
+    @ParameterizedTest(name = "#{index}: should return all unique values from database: {0}")
+    @MethodSource("databaseArgumentsProvider")
+    void bronhouder_unique_values_test(String url, String... expected) throws Exception {
+        MvcResult result =
+                mockMvc.perform(
+                                get(url).contentType(MediaType.APPLICATION_JSON)
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.filterApplied").value(false))
+                        .andExpect(jsonPath("$.values").isArray())
+                        .andExpect(jsonPath("$.values").isNotEmpty())
+                        .andReturn();
+
+        final String body = result.getResponse().getContentAsString();
+        List<String> values = JsonPath.read(body, "$.values");
+        final Set<String> uniqueValues = new HashSet<>(values);
+
+        assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
+        assertTrue(uniqueValues.containsAll(Set.of(expected)), "not all values are present");
+    }
+
+    @ParameterizedTest(
+            name =
+                    "#{index}: should return unique bronhouder from database when filtered on bronhouder: {0}")
+    @MethodSource("databaseArgumentsProvider")
+    void bronhouder_with_filter_on_bronhouder_unique_values_test(String url, String... expected)
+            throws Exception {
+        String cqlFilter = "bronhouder='G0344'";
+        if (url.contains("BRONHOUDER")) {
+            // uppercase oracle cql filter
+            cqlFilter = cqlFilter.toUpperCase();
+        }
+
+        MvcResult result =
+                mockMvc.perform(
+                                get(url).param("filter", cqlFilter)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.filterApplied").value(true))
+                        .andExpect(jsonPath("$.values").isArray())
+                        .andExpect(jsonPath("$.values").isNotEmpty())
+                        .andReturn();
+
+        final String body = result.getResponse().getContentAsString();
+        List<String> values = JsonPath.read(body, "$.values");
+
+        assertEquals(1, values.size(), "there should only be 1 value");
+        assertTrue(List.of(expected).contains(values.get(0)), "not all values are present");
+    }
+
+    @ParameterizedTest(
+            name =
+                    "#{index}: should return no unique bronhouder from database with exclusion filter: {0}")
+    @MethodSource("databaseArgumentsProvider")
+    void bronhouder_with_filter_on_inonderzoek_unique_values_test(String url, String... expected)
+            throws Exception {
+        String cqlFilter = "inonderzoek=TRUE";
+        if (url.contains("BRONHOUDER")) {
+            // uppercase oracle cql filter
+            cqlFilter = cqlFilter.toUpperCase();
+        }
+
+        mockMvc.perform(
+                        get(url).param("filter", cqlFilter)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.filterApplied").value(true))
+                .andExpect(jsonPath("$.values").isArray())
+                .andExpect(jsonPath("$.values").isEmpty());
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void broken_filter_returns_bad_request_message() throws Exception {
+        mockMvc.perform(
+                        get(begroeidterreindeelPostgisUrl + "bronhouder")
+                                .param("filter", "naam or Utrecht"))
+                .andExpect(status().is4xxClientError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(
+                        jsonPath("$.message")
+                                .value("Bad Request. Could not parse requested filter."));
+    }
+
+    @RetryingTest(2)
+    void unique_values_from_wfs() throws Exception {
+        MvcResult result =
+                mockMvc.perform(
+                                get(provinciesWFSUrl)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.filterApplied").value(false))
+                        .andExpect(jsonPath("$.values").isArray())
+                        .andExpect(jsonPath("$.values").isNotEmpty())
+                        .andReturn();
+
+        final String body =
+                result.getResponse().getContentAsString(/* for Fryslân */ StandardCharsets.UTF_8);
+        final List<String> values = JsonPath.read(body, "$.values");
+        assertEquals(12, values.size(), "there should be 12 provinces");
+
+        final Set<String> uniqueValues = new HashSet<>(values);
+        assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
+        assertTrue(
+                uniqueValues.containsAll(
+                        Arrays.asList(
+                                "Noord-Brabant",
+                                "Zuid-Holland",
+                                "Utrecht",
+                                "Groningen",
+                                "Drenthe",
+                                "Fryslân",
+                                "Zeeland",
+                                "Limburg",
+                                "Noord-Holland",
+                                "Gelderland",
+                                "Flevoland",
+                                "Overijssel")),
+                "not all values are present");
+    }
+
+    @RetryingTest(2)
+    void unique_values_from_wfs_with_filter_on_same() throws Exception {
+        String cqlFilter = "naam='Utrecht'";
+        mockMvc.perform(
+                        get(provinciesWFSUrl)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .param("filter", cqlFilter))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.filterApplied").value(true))
+                .andExpect(jsonPath("$.values").isArray())
+                .andExpect(jsonPath("$.values.length()").value(1))
+                .andExpect(jsonPath("$.values[0]").value("Utrecht"));
+    }
+
+    @RetryingTest(2)
+    void unique_values_from_wfs_with_filter_on_different() throws Exception {
+        String cqlFilter = "naam like '%Holland'";
+
+        mockMvc.perform(
+                        get(provinciesWFSUrl)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .param("filter", cqlFilter))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.filterApplied").value(true))
+                .andExpect(jsonPath("$.values").isArray())
+                .andExpect(jsonPath("$.values.length()").value(2))
+                .andExpect(jsonPath("$.values[0]").value(Matchers.containsString("-Holland")))
+                .andExpect(jsonPath("$.values[1]").value(Matchers.containsString("-Holland")));
+    }
+
+    /**
+     * Testcase for <a href="https://b3partners.atlassian.net/browse/HTM-492">HTM-492</a> where
+     * Jakson fails to process oracle.sql.TIMESTAMP.
+     *
+     * <p>The exception is: {@code org.springframework.web.util.NestedServletException: Request
+     * processing failed; nested exception is
+     * org.springframework.http.converter.HttpMessageConversionException: Type definition error:
+     * [simple type, class java.io.ByteArrayInputStream]; nested exception is
+     * com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class
+     * java.io.ByteArrayInputStream and no properties discovered to create BeanSerializer (to avoid
+     * exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain:
+     * nl.b3p.tailormap.api.model.UniqueValuesResponse["values"]->java.util.HashSet[0]->oracle.sql.TIMESTAMP["stream"])
+     * }
+     *
+     * @throws Exception if any
+     */
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void unique_values_oracle_timestamp_HTM_492() throws Exception {
+        final String testUrl = "/app/1/layer/7/unique/TIJDSTIPREGISTRATIE";
+        mockMvc.perform(
+                        get(testUrl)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.filterApplied").value(false))
+                .andExpect(jsonPath("$.values").isArray())
+                .andExpect(jsonPath("$.values").isNotEmpty());
+    }
+}

--- a/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerReConfiguredPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerReConfiguredPostgresIntegrationTest.java
@@ -14,11 +14,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jayway.jsonpath.JsonPath;
-
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 import nl.b3p.tailormap.api.JPAConfiguration;
 import nl.b3p.tailormap.api.security.AuthorizationService;
 import nl.b3p.tailormap.api.security.SecurityConfig;
-
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -38,20 +42,13 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
-
 @SpringBootTest(
-        classes = {
-            JPAConfiguration.class,
-            UniqueValuesController.class,
-            SecurityConfig.class,
-            AuthorizationService.class
-        })
+    classes = {
+      JPAConfiguration.class,
+      UniqueValuesController.class,
+      SecurityConfig.class,
+      AuthorizationService.class
+    })
 @AutoConfigureMockMvc
 @EnableAutoConfiguration
 @ActiveProfiles("postgresql")
@@ -59,221 +56,219 @@ import java.util.stream.Stream;
 @Stopwatch
 @TestPropertySource(properties = {"tailormap-api.unique.use_geotools_unique_function=false"})
 class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
-    private static final String provinciesWFSUrl = "/app/1/layer/2/unique/naam";
-    private static final String begroeidterreindeelPostgisUrl = "/app/1/layer/6/unique/bronhouder";
-    private static final String waterdeelOracleUrl = "/app/1/layer/7/unique/BRONHOUDER";
-    private static final String wegdeelSqlserverUrl = "/app/1/layer/9/unique/bronhouder";
-    @Autowired private MockMvc mockMvc;
+  private static final String provinciesWFSUrl = "/app/1/layer/2/unique/naam";
+  private static final String begroeidterreindeelPostgisUrl = "/app/1/layer/6/unique/bronhouder";
+  private static final String waterdeelOracleUrl = "/app/1/layer/7/unique/BRONHOUDER";
+  private static final String wegdeelSqlserverUrl = "/app/1/layer/9/unique/bronhouder";
+  @Autowired private MockMvc mockMvc;
 
-    /** layer url + bronhouders. */
-    static Stream<Arguments> databaseArgumentsProvider() {
-        return Stream.of(
-                arguments(
-                        begroeidterreindeelPostgisUrl,
-                        new String[] {
-                            "W0636", "G0344", "L0004", "W0155", "L0001", "P0026", "L0002", "G1904"
-                        }),
-                arguments(
-                        waterdeelOracleUrl,
-                        new String[] {
-                            "W0636", "P0026", "L0002", "W0155", "G1904", "G0344", "L0004"
-                        }),
-                arguments(
-                        wegdeelSqlserverUrl,
-                        new String[] {"P0026", "G0344", "G1904", "L0004", "L0002"}));
+  /** layer url + bronhouders. */
+  static Stream<Arguments> databaseArgumentsProvider() {
+    return Stream.of(
+        arguments(
+            begroeidterreindeelPostgisUrl,
+            new String[] {"W0636", "G0344", "L0004", "W0155", "L0001", "P0026", "L0002", "G1904"}),
+        arguments(
+            waterdeelOracleUrl,
+            new String[] {"W0636", "P0026", "L0002", "W0155", "G1904", "G0344", "L0004"}),
+        arguments(wegdeelSqlserverUrl, new String[] {"P0026", "G0344", "G1904", "L0004", "L0002"}));
+  }
+
+  @ParameterizedTest(name = "#{index}: should return all unique values from database: {0}")
+  @MethodSource("databaseArgumentsProvider")
+  void bronhouder_unique_values_test(String url, String... expected) throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                get(url).contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.filterApplied").value(false))
+            .andExpect(jsonPath("$.values").isArray())
+            .andExpect(jsonPath("$.values").isNotEmpty())
+            .andReturn();
+
+    final String body = result.getResponse().getContentAsString();
+    List<String> values = JsonPath.read(body, "$.values");
+    final Set<String> uniqueValues = new HashSet<>(values);
+
+    assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
+    assertTrue(uniqueValues.containsAll(Set.of(expected)), "not all values are present");
+  }
+
+  @ParameterizedTest(
+      name =
+          "#{index}: should return unique bronhouder from database when filtered on bronhouder: {0}")
+  @MethodSource("databaseArgumentsProvider")
+  void bronhouder_with_filter_on_bronhouder_unique_values_test(String url, String... expected)
+      throws Exception {
+    String cqlFilter = "bronhouder='G0344'";
+    if (url.contains("BRONHOUDER")) {
+      // uppercase oracle cql filter
+      cqlFilter = cqlFilter.toUpperCase();
     }
 
-    @ParameterizedTest(name = "#{index}: should return all unique values from database: {0}")
-    @MethodSource("databaseArgumentsProvider")
-    void bronhouder_unique_values_test(String url, String... expected) throws Exception {
-        MvcResult result =
-                mockMvc.perform(
-                                get(url).contentType(MediaType.APPLICATION_JSON)
-                                        .accept(MediaType.APPLICATION_JSON))
-                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.filterApplied").value(false))
-                        .andExpect(jsonPath("$.values").isArray())
-                        .andExpect(jsonPath("$.values").isNotEmpty())
-                        .andReturn();
+    MvcResult result =
+        mockMvc
+            .perform(
+                get(url)
+                    .param("filter", cqlFilter)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.filterApplied").value(true))
+            .andExpect(jsonPath("$.values").isArray())
+            .andExpect(jsonPath("$.values").isNotEmpty())
+            .andReturn();
 
-        final String body = result.getResponse().getContentAsString();
-        List<String> values = JsonPath.read(body, "$.values");
-        final Set<String> uniqueValues = new HashSet<>(values);
+    final String body = result.getResponse().getContentAsString();
+    List<String> values = JsonPath.read(body, "$.values");
 
-        assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
-        assertTrue(uniqueValues.containsAll(Set.of(expected)), "not all values are present");
+    assertEquals(1, values.size(), "there should only be 1 value");
+    assertTrue(List.of(expected).contains(values.get(0)), "not all values are present");
+  }
+
+  @ParameterizedTest(
+      name =
+          "#{index}: should return no unique bronhouder from database with exclusion filter: {0}")
+  @MethodSource("databaseArgumentsProvider")
+  void bronhouder_with_filter_on_inonderzoek_unique_values_test(String url, String... expected)
+      throws Exception {
+    String cqlFilter = "inonderzoek=TRUE";
+    if (url.contains("BRONHOUDER")) {
+      // uppercase oracle cql filter
+      cqlFilter = cqlFilter.toUpperCase();
     }
 
-    @ParameterizedTest(
-            name =
-                    "#{index}: should return unique bronhouder from database when filtered on bronhouder: {0}")
-    @MethodSource("databaseArgumentsProvider")
-    void bronhouder_with_filter_on_bronhouder_unique_values_test(String url, String... expected)
-            throws Exception {
-        String cqlFilter = "bronhouder='G0344'";
-        if (url.contains("BRONHOUDER")) {
-            // uppercase oracle cql filter
-            cqlFilter = cqlFilter.toUpperCase();
-        }
+    mockMvc
+        .perform(
+            get(url)
+                .param("filter", cqlFilter)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.filterApplied").value(true))
+        .andExpect(jsonPath("$.values").isArray())
+        .andExpect(jsonPath("$.values").isEmpty());
+  }
 
-        MvcResult result =
-                mockMvc.perform(
-                                get(url).param("filter", cqlFilter)
-                                        .contentType(MediaType.APPLICATION_JSON)
-                                        .accept(MediaType.APPLICATION_JSON))
-                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.filterApplied").value(true))
-                        .andExpect(jsonPath("$.values").isArray())
-                        .andExpect(jsonPath("$.values").isNotEmpty())
-                        .andReturn();
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void broken_filter_returns_bad_request_message() throws Exception {
+    mockMvc
+        .perform(
+            get(begroeidterreindeelPostgisUrl + "bronhouder").param("filter", "naam or Utrecht"))
+        .andExpect(status().is4xxClientError())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.message").value("Bad Request. Could not parse requested filter."));
+  }
 
-        final String body = result.getResponse().getContentAsString();
-        List<String> values = JsonPath.read(body, "$.values");
+  @RetryingTest(2)
+  void unique_values_from_wfs() throws Exception {
+    MvcResult result =
+        mockMvc
+            .perform(
+                get(provinciesWFSUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.filterApplied").value(false))
+            .andExpect(jsonPath("$.values").isArray())
+            .andExpect(jsonPath("$.values").isNotEmpty())
+            .andReturn();
 
-        assertEquals(1, values.size(), "there should only be 1 value");
-        assertTrue(List.of(expected).contains(values.get(0)), "not all values are present");
-    }
+    final String body =
+        result.getResponse().getContentAsString(/* for Fryslân */ StandardCharsets.UTF_8);
+    final List<String> values = JsonPath.read(body, "$.values");
+    assertEquals(12, values.size(), "there should be 12 provinces");
 
-    @ParameterizedTest(
-            name =
-                    "#{index}: should return no unique bronhouder from database with exclusion filter: {0}")
-    @MethodSource("databaseArgumentsProvider")
-    void bronhouder_with_filter_on_inonderzoek_unique_values_test(String url, String... expected)
-            throws Exception {
-        String cqlFilter = "inonderzoek=TRUE";
-        if (url.contains("BRONHOUDER")) {
-            // uppercase oracle cql filter
-            cqlFilter = cqlFilter.toUpperCase();
-        }
+    final Set<String> uniqueValues = new HashSet<>(values);
+    assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
+    assertTrue(
+        uniqueValues.containsAll(
+            Arrays.asList(
+                "Noord-Brabant",
+                "Zuid-Holland",
+                "Utrecht",
+                "Groningen",
+                "Drenthe",
+                "Fryslân",
+                "Zeeland",
+                "Limburg",
+                "Noord-Holland",
+                "Gelderland",
+                "Flevoland",
+                "Overijssel")),
+        "not all values are present");
+  }
 
-        mockMvc.perform(
-                        get(url).param("filter", cqlFilter)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.filterApplied").value(true))
-                .andExpect(jsonPath("$.values").isArray())
-                .andExpect(jsonPath("$.values").isEmpty());
-    }
+  @RetryingTest(2)
+  void unique_values_from_wfs_with_filter_on_same() throws Exception {
+    String cqlFilter = "naam='Utrecht'";
+    mockMvc
+        .perform(
+            get(provinciesWFSUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .param("filter", cqlFilter))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.filterApplied").value(true))
+        .andExpect(jsonPath("$.values").isArray())
+        .andExpect(jsonPath("$.values.length()").value(1))
+        .andExpect(jsonPath("$.values[0]").value("Utrecht"));
+  }
 
-    @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-    void broken_filter_returns_bad_request_message() throws Exception {
-        mockMvc.perform(
-                        get(begroeidterreindeelPostgisUrl + "bronhouder")
-                                .param("filter", "naam or Utrecht"))
-                .andExpect(status().is4xxClientError())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.code").value(400))
-                .andExpect(
-                        jsonPath("$.message")
-                                .value("Bad Request. Could not parse requested filter."));
-    }
+  @RetryingTest(2)
+  void unique_values_from_wfs_with_filter_on_different() throws Exception {
+    String cqlFilter = "naam like '%Holland'";
 
-    @RetryingTest(2)
-    void unique_values_from_wfs() throws Exception {
-        MvcResult result =
-                mockMvc.perform(
-                                get(provinciesWFSUrl)
-                                        .contentType(MediaType.APPLICATION_JSON)
-                                        .accept(MediaType.APPLICATION_JSON))
-                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.filterApplied").value(false))
-                        .andExpect(jsonPath("$.values").isArray())
-                        .andExpect(jsonPath("$.values").isNotEmpty())
-                        .andReturn();
+    mockMvc
+        .perform(
+            get(provinciesWFSUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .param("filter", cqlFilter))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.filterApplied").value(true))
+        .andExpect(jsonPath("$.values").isArray())
+        .andExpect(jsonPath("$.values.length()").value(2))
+        .andExpect(jsonPath("$.values[0]").value(Matchers.containsString("-Holland")))
+        .andExpect(jsonPath("$.values[1]").value(Matchers.containsString("-Holland")));
+  }
 
-        final String body =
-                result.getResponse().getContentAsString(/* for Fryslân */ StandardCharsets.UTF_8);
-        final List<String> values = JsonPath.read(body, "$.values");
-        assertEquals(12, values.size(), "there should be 12 provinces");
-
-        final Set<String> uniqueValues = new HashSet<>(values);
-        assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
-        assertTrue(
-                uniqueValues.containsAll(
-                        Arrays.asList(
-                                "Noord-Brabant",
-                                "Zuid-Holland",
-                                "Utrecht",
-                                "Groningen",
-                                "Drenthe",
-                                "Fryslân",
-                                "Zeeland",
-                                "Limburg",
-                                "Noord-Holland",
-                                "Gelderland",
-                                "Flevoland",
-                                "Overijssel")),
-                "not all values are present");
-    }
-
-    @RetryingTest(2)
-    void unique_values_from_wfs_with_filter_on_same() throws Exception {
-        String cqlFilter = "naam='Utrecht'";
-        mockMvc.perform(
-                        get(provinciesWFSUrl)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON)
-                                .param("filter", cqlFilter))
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.filterApplied").value(true))
-                .andExpect(jsonPath("$.values").isArray())
-                .andExpect(jsonPath("$.values.length()").value(1))
-                .andExpect(jsonPath("$.values[0]").value("Utrecht"));
-    }
-
-    @RetryingTest(2)
-    void unique_values_from_wfs_with_filter_on_different() throws Exception {
-        String cqlFilter = "naam like '%Holland'";
-
-        mockMvc.perform(
-                        get(provinciesWFSUrl)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON)
-                                .param("filter", cqlFilter))
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.filterApplied").value(true))
-                .andExpect(jsonPath("$.values").isArray())
-                .andExpect(jsonPath("$.values.length()").value(2))
-                .andExpect(jsonPath("$.values[0]").value(Matchers.containsString("-Holland")))
-                .andExpect(jsonPath("$.values[1]").value(Matchers.containsString("-Holland")));
-    }
-
-    /**
-     * Testcase for <a href="https://b3partners.atlassian.net/browse/HTM-492">HTM-492</a> where
-     * Jakson fails to process oracle.sql.TIMESTAMP.
-     *
-     * <p>The exception is: {@code org.springframework.web.util.NestedServletException: Request
-     * processing failed; nested exception is
-     * org.springframework.http.converter.HttpMessageConversionException: Type definition error:
-     * [simple type, class java.io.ByteArrayInputStream]; nested exception is
-     * com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class
-     * java.io.ByteArrayInputStream and no properties discovered to create BeanSerializer (to avoid
-     * exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain:
-     * nl.b3p.tailormap.api.model.UniqueValuesResponse["values"]->java.util.HashSet[0]->oracle.sql.TIMESTAMP["stream"])
-     * }
-     *
-     * @throws Exception if any
-     */
-    @Test
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-    void unique_values_oracle_timestamp_HTM_492() throws Exception {
-        final String testUrl = "/app/1/layer/7/unique/TIJDSTIPREGISTRATIE";
-        mockMvc.perform(
-                        get(testUrl)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.filterApplied").value(false))
-                .andExpect(jsonPath("$.values").isArray())
-                .andExpect(jsonPath("$.values").isNotEmpty());
-    }
+  /**
+   * Testcase for <a href="https://b3partners.atlassian.net/browse/HTM-492">HTM-492</a> where Jakson
+   * fails to process oracle.sql.TIMESTAMP.
+   *
+   * <p>The exception is: {@code org.springframework.web.util.NestedServletException: Request
+   * processing failed; nested exception is
+   * org.springframework.http.converter.HttpMessageConversionException: Type definition error:
+   * [simple type, class java.io.ByteArrayInputStream]; nested exception is
+   * com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class
+   * java.io.ByteArrayInputStream and no properties discovered to create BeanSerializer (to avoid
+   * exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain:
+   * nl.b3p.tailormap.api.model.UniqueValuesResponse["values"]->java.util.HashSet[0]->oracle.sql.TIMESTAMP["stream"])
+   * }
+   *
+   * @throws Exception if any
+   */
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void unique_values_oracle_timestamp_HTM_492() throws Exception {
+    final String testUrl = "/app/1/layer/7/unique/TIJDSTIPREGISTRATIE";
+    mockMvc
+        .perform(
+            get(testUrl).contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.filterApplied").value(false))
+        .andExpect(jsonPath("$.values").isArray())
+        .andExpect(jsonPath("$.values").isNotEmpty());
+  }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -23,3 +23,6 @@ spring.jmx.enabled=false
 logging.level.org.springframework=INFO
 
 logging.level.nl.b3p.tailormap.api=TRACE
+
+# log all GeoTools SQL queries
+logging.level.org.geotools.jdbc=DEBUG


### PR DESCRIPTION
- [x] Testcase illustrating the problem a7dd5509e1fe95fd59cef7e759d42e0668ca8998
- [x] Test demonstrating a workaround af897b1939892a6f44218d9dc80d1a2bee2e1b23
- [x] solution for HTM-492: You must set the Oracle connection property `oracle.jdbc.J2EE13Compliant=true` either as an environment variable or as part of the connect string eg. using the value `/XEPDB1?oracle.jdbc.J2EE13Compliant=true` for the database field or `-Doracle.jdbc.J2EE13Compliant=true` on the command line
