### PR TITLE
[HTM-466] enable Sentry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,6 +427,11 @@ SPDX-License-Identifier: MIT
       <artifactId>sentry-spring-boot-starter</artifactId>
       <version>${sentry.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-jdbc</artifactId>
+      <version>${sentry.version}</version>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>
@@ -447,6 +452,7 @@ SPDX-License-Identifier: MIT
           <include>**/index.html</include>
           <include>**/application*.properties</include>
           <include>**/git.properties</include>
+          <include>**/spy.properties</include>
         </includes>
       </resource>
       <resource>
@@ -455,6 +461,7 @@ SPDX-License-Identifier: MIT
           <exclude>**/index.html</exclude>
           <exclude>**/application*.properties</exclude>
           <exclude>**/git.properties</exclude>
+          <exclude>**/spy.properties</exclude>
         </excludes>
       </resource>
       <resource>
@@ -1122,6 +1129,7 @@ SPDX-License-Identifier: MIT
                     <exclude>org.hibernate:hibernate-micrometer</exclude>
                     <exclude>com.microsoft.sqlserver:mssql-jdbc:jar</exclude>
                     <exclude>io.sentry:sentry-spring-boot-starter</exclude>
+                    <exclude>p6spy:p6spy:jar</exclude>
                     <!--
                     TODO this should be fixed; either by importing or excluding the transitive dependencies
                     nl.b3p.tailormap:viewer-config-persistence:jar:5.9.12-SNAPSHOT:compile has transitive dependencies:

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@ SPDX-License-Identifier: MIT
     <docker.skip>false</docker.skip>
     <maven-fluido-skin.version>1.11.1</maven-fluido-skin.version>
     <swagger-ui.version>4.14.3</swagger-ui.version>
+    <sentry.version>6.5.0</sentry.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -421,6 +422,11 @@ SPDX-License-Identifier: MIT
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-spring-boot-starter</artifactId>
+      <version>${sentry.version}</version>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>
@@ -440,13 +446,15 @@ SPDX-License-Identifier: MIT
         <includes>
           <include>**/index.html</include>
           <include>**/application*.properties</include>
+          <include>**/git.properties</include>
         </includes>
       </resource>
       <resource>
         <directory>${basedir}/src/main/resources</directory>
         <excludes>
-          <exclude>**/application*.properties</exclude>
           <exclude>**/index.html</exclude>
+          <exclude>**/application*.properties</exclude>
+          <exclude>**/git.properties</exclude>
         </excludes>
       </resource>
       <resource>
@@ -547,7 +555,7 @@ SPDX-License-Identifier: MIT
         <artifactId>git-commit-id-maven-plugin</artifactId>
         <version>5.0.0</version>
         <configuration>
-          <generateGitPropertiesFile>false</generateGitPropertiesFile>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
         </configuration>
         <executions>
           <execution>
@@ -1113,6 +1121,7 @@ SPDX-License-Identifier: MIT
                     <exclude>io.micrometer:micrometer-registry-prometheus</exclude>
                     <exclude>org.hibernate:hibernate-micrometer</exclude>
                     <exclude>com.microsoft.sqlserver:mssql-jdbc:jar</exclude>
+                    <exclude>io.sentry:sentry-spring-boot-starter</exclude>
                     <!--
                     TODO this should be fixed; either by importing or excluding the transitive dependencies
                     nl.b3p.tailormap:viewer-config-persistence:jar:5.9.12-SNAPSHOT:compile has transitive dependencies:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,7 +32,7 @@ spring.application.name==@project.artifactId@
 spring.datasource.url=jdbc:postgresql://127.0.0.1/tailormap
 spring.datasource.username=tailormap
 spring.datasource.password=tailormap
-spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.driver-class-name=com.p6spy.engine.spy.P6SpyDriver
 spring.datasource.pool-size=30
 
 #

--- a/src/main/resources/spy.properties
+++ b/src/main/resources/spy.properties
@@ -1,0 +1,2 @@
+modulelist=com.p6spy.engine.spy.P6SpyFactory
+driverlist=org.postgresql.Driver


### PR DESCRIPTION
Uses the standard Sentry environment variables, `SENTRY_DSN` and `SENTRY_TRACES_SAMPLE_RATE`. No other integration other than the default, for now.

The release ID used to link versions to Sentry is the git commit hash. If `SENTRY_DSN` is not set, no Sentry logging will happen.