### PR TITLE
[HTM-527] set-up multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ LABEL org.opencontainers.image.authors="support@b3partners.nl" \
       org.opencontainers.image.version=$TAILORMAP_API_VERSION
 
 # set-up timezone and local user
-RUN set -eux;ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN apt upgrade -y && apt autoremove -y && apt autoclean && apt clean && rm -rf /tmp/* && rm -rf /var/tmp/* && rm -rf /var/lib/apt/lists/*
-RUN useradd -ms /bin/bash spring
+RUN set -eux;ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+    && apt upgrade -y && apt autoremove -y && apt autoclean && apt clean && rm -rf /tmp/* && rm -rf /var/tmp/* && rm -rf /var/lib/apt/lists/* \
+    && useradd -ms /bin/bash spring
 
 USER spring:spring
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: MIT
 #
-FROM eclipse-temurin:11.0.16.1_1-jre-alpine
+FROM eclipse-temurin:11.0.16.1_1-jre
 
 
-ARG TAILORMAP_API_VERSION="10.0-SNAPSHOT"
+ARG TAILORMAP_API_VERSION="10.0.0-rc2-SNAPSHOT"
 ARG TZ="Europe/Amsterdam"
 ARG DEBIAN_FRONTEND="noninteractive"
 
@@ -26,10 +26,9 @@ LABEL org.opencontainers.image.authors="support@b3partners.nl" \
       org.opencontainers.image.version=$TAILORMAP_API_VERSION
 
 # set-up timezone and local user
-RUN set -eux;ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
-    && addgroup -S spring && adduser -S spring -G spring \
-    # for CVE-2022-40674, this can probably be removed when we upgrade the base image > eclipse-temurin:11.0.16.1_1-jre-alpine
-    && apk add --no-cache expat=2.4.9-r0
+RUN set -eux;ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN apt upgrade -y && apt autoremove -y && apt autoclean && apt clean && rm -rf /tmp/* && rm -rf /var/tmp/* && rm -rf /var/lib/apt/lists/*
+RUN useradd -ms /bin/bash spring
 
 USER spring:spring
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ Tailormap API provides the OpenAPI for Tailormap.
 
 ## Development
 
-Basic procedure:
+### Prerequisites
+
+To fully build the project, you need to have the following installed:
+
+- Java 11 JDK
+- Maven 3.8.4 or higher
+- Docker 1.9 or higher (this requirement can be skipped if you don't need to build the docker image or build release artifacts)
+
+### Basic procedure:
 
 1. do your thing, if possible use `aosp` styling (run `mvn com.coveo:fmt-maven-plugin:format` to fix all formatting)
 2. run `mvn clean install` to make sure all required formatting is applied and all tests pass
@@ -24,23 +32,28 @@ see also [QA](#QA)
 
 ### Profiles
 
-Some Maven profiles are defined:
+Some Maven (platform specific) profiles are defined:
 
 * **macos**
     - Sets specific properties for MacOS such as skipping the docker part of the build
     - Activated automagically
+* **openbsd**
+  - Sets specific properties for OpenBSD such as skipping the docker part of the build
+  - Activated automagically
 * **windows**
     - Sets specific properties for Windows such as skipping the docker part of the build
     - Activated automagically
 * **release**
     - Release specific configuration
-    - Activated automagically
+    - Activated automagically during Maven release procedure
 * **developing**
     - Sets specific properties for use in the IDE such as disabling docker build and QA
     - Activated using the flag `-Pdeveloping` or checking the option in your IDE
 * **qa-skip**
     - Will skip any "QA" Maven plugins defined with a defined `skip` element
     - Activated using flag `-DskipQA=true`
+
+**Note:** The platform specific profiles (`macos`,`openbsd` and `windows`) cannot be used to create releases.
 
 ## QA
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ To fully build the project, you need to have the following installed:
 
 - Java 11 JDK
 - Maven 3.8.4 or higher
-- Docker 1.9 or higher (this requirement can be skipped if you don't need to build the docker image or build release artifacts)
+- Docker 20.10.x with buildx 0.9 or higher (this requirement may be skipped if you don't need to build 
+  the docker images or build release artifacts)
 
 ### Basic procedure:
 

--- a/pom.xml
+++ b/pom.xml
@@ -1463,8 +1463,8 @@ SPDX-License-Identifier: MIT
       <id>openbsd</id>
       <activation>
         <os>
-          <family>unix</family>
           <name>openbsd</name>
+          <family>unix</family>
         </os>
       </activation>
       <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1171,6 +1171,12 @@ SPDX-License-Identifier: MIT
                 <args>
                   <TAILORMAP_API_VERSION>${project.version}</TAILORMAP_API_VERSION>
                 </args>
+                <buildx>
+                  <platforms>
+                    <platform>linux/amd64</platform>
+                    <platform>linux/arm64</platform>
+                  </platforms>
+                </buildx>
               </build>
             </image>
           </images>

--- a/pom.xml
+++ b/pom.xml
@@ -1460,6 +1460,18 @@ SPDX-License-Identifier: MIT
       </properties>
     </profile>
     <profile>
+      <id>openbsd</id>
+      <activation>
+        <os>
+          <family>unix</family>
+          <name>openbsd</name>
+        </os>
+      </activation>
+      <properties>
+        <docker.skip>true</docker.skip>
+      </properties>
+    </profile>
+    <profile>
       <id>windows</id>
       <activation>
         <os>


### PR DESCRIPTION
for now stick to `linux/amd64` and `linux/arm64` (`linux/arm64/v8`)

- [x] setup `pom.xml` with buildx/multi-arch
- [x] change base docker image from `eclipse-temurin:11.0.16.1_1-jre-alpine` to `eclipse-temurin:11.0.16.1_1-jre` (there is no alpine arm64 jre image)
- [x] update build requirements and documentation
- [x] add automatic profiles for OS/platforms that don't support docker to skip the docker build (would only build/est the executable jar)

resolves HTM-527