### PR TITLE
Update ubuntu packages before upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ LABEL org.opencontainers.image.authors="support@b3partners.nl" \
 
 # set-up timezone and local user
 RUN set -eux;ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
-    && apt upgrade -y && apt autoremove -y && apt autoclean && apt clean && rm -rf /tmp/* && rm -rf /var/tmp/* && rm -rf /var/lib/apt/lists/* \
+    && apt update && apt upgrade -y && apt autoremove -y && apt autoclean && apt clean && rm -rf /tmp/* && rm -rf /var/tmp/* && rm -rf /var/lib/apt/lists/* \
     && useradd -ms /bin/bash spring
 
 USER spring:spring


### PR DESCRIPTION
resolves curl vulnerabilities CVE-2022-32221, CVE-2022-42915 and CVE-2022-42916