### PR TITLE
OGC WMS/WMTS proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,28 @@ SPDX-License-Identifier: MIT
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.hateoas</groupId>
+      <artifactId>spring-hateoas</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-beans</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.plugin</groupId>
+          <artifactId>spring-plugin-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -230,24 +230,6 @@ SPDX-License-Identifier: MIT
     <dependency>
       <groupId>org.springframework.hateoas</groupId>
       <artifactId>spring-hateoas</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-beans</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-context</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.springframework.plugin</groupId>
-          <artifactId>spring-plugin-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
@@ -1147,6 +1129,7 @@ SPDX-License-Identifier: MIT
                     <exclude>org.springframework.security:spring-security-test</exclude>
                     <exclude>org.webjars:webjars-locator-core</exclude>
                     <exclude>org.springframework.boot:spring-boot-starter-aop</exclude>
+                    <exclude>org.springframework.hateoas:spring-hateoas</exclude>
                     <exclude>io.micrometer:micrometer-registry-prometheus</exclude>
                     <exclude>org.hibernate:hibernate-micrometer</exclude>
                     <exclude>com.microsoft.sqlserver:mssql-jdbc:jar</exclude>

--- a/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
@@ -6,6 +6,7 @@
 package nl.b3p.tailormap.api.controller;
 
 import io.swagger.v3.oas.annotations.Parameter;
+
 import nl.b3p.tailormap.api.model.RedirectResponse;
 import nl.b3p.tailormap.api.repository.ApplicationLayerRepository;
 import nl.b3p.tailormap.api.repository.ApplicationRepository;
@@ -15,6 +16,7 @@ import nl.tailormap.viewer.config.app.ApplicationLayer;
 import nl.tailormap.viewer.config.services.GeoService;
 import nl.tailormap.viewer.config.services.TileService;
 import nl.tailormap.viewer.config.services.WMSService;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +34,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import javax.servlet.http.HttpServletRequest;
 import java.io.InputStream;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -46,6 +47,8 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * Proxy controller for OGC WMS and WMTS services. Does not attempt to hide the original service
@@ -140,7 +143,7 @@ public class GeoServiceProxyController {
 
         final Application application = applicationRepository.findById(appId).orElse(null);
         final ApplicationLayer appLayer =
-                 applicationLayerRepository.findById(appLayerId).orElse(null);
+                applicationLayerRepository.findById(appLayerId).orElse(null);
         if (application == null || appLayer == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body("Requested an application or appLayer that does not exist");

--- a/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2022 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.controller;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import nl.b3p.tailormap.api.model.ErrorResponse;
+import nl.b3p.tailormap.api.model.RedirectResponse;
+import nl.b3p.tailormap.api.repository.ApplicationLayerRepository;
+import nl.b3p.tailormap.api.repository.ApplicationRepository;
+import nl.b3p.tailormap.api.security.AuthorizationService;
+import nl.tailormap.viewer.config.app.Application;
+import nl.tailormap.viewer.config.app.ApplicationLayer;
+import nl.tailormap.viewer.config.services.GeoService;
+import nl.tailormap.viewer.config.services.TileService;
+import nl.tailormap.viewer.config.services.WMSService;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.InputStream;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import javax.persistence.EntityNotFoundException;
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@Validated
+@RequestMapping(path = "/app/{appId}/layer/{appLayerId}/proxy")
+@SuppressWarnings("unused")
+public class GeoServiceProxyController {
+
+    private final Log logger = LogFactory.getLog(getClass());
+    private final ApplicationRepository applicationRepository;
+    private final ApplicationLayerRepository applicationLayerRepository;
+    private final AuthorizationService authorizationService;
+
+    @Autowired
+    public GeoServiceProxyController(
+            ApplicationRepository applicationRepository,
+            ApplicationLayerRepository applicationLayerRepository,
+            AuthorizationService authorizationService) {
+        this.applicationRepository = applicationRepository;
+        this.applicationLayerRepository = applicationLayerRepository;
+        this.authorizationService = authorizationService;
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    @ResponseStatus(
+            value =
+                    HttpStatus
+                            .NOT_FOUND /*,reason = "Not Found" -- adding 'reason' will drop the body */)
+    @ResponseBody
+    public ErrorResponse handleEntityNotFoundException(EntityNotFoundException exception) {
+        logger.warn(
+                "Requested an application or appLayer that does not exist. Message: "
+                        + exception.getMessage());
+        return new ErrorResponse()
+                .message("Requested an application or appLayer that does not exist")
+                .code(HttpStatus.NOT_FOUND.value());
+    }
+
+    @GetMapping(path = "/wmts")
+    public ResponseEntity<?> proxyWmts(
+            @Parameter(name = "appId", description = "application id", required = true)
+                    @PathVariable("appId")
+                    Long appId,
+            @Parameter(name = "appLayerId", description = "application layer id", required = true)
+                    @PathVariable("appLayerId")
+                    Long appLayerId,
+            HttpServletRequest request) {
+        return proxy(
+                (GeoService gs) ->
+                        TileService.PROTOCOL.equals(gs.getProtocol())
+                                && TileService.TILING_PROTOCOL_WMTS.equals(
+                                        ((TileService) gs).getTilingProtocol()),
+                appId,
+                appLayerId,
+                request);
+    }
+
+    @GetMapping(path = "/wms")
+    public ResponseEntity<?> proxyWms(
+            @Parameter(name = "appId", description = "application id", required = true)
+                    @PathVariable("appId")
+                    Long appId,
+            @Parameter(name = "appLayerId", description = "application layer id", required = true)
+                    @PathVariable("appLayerId")
+                    Long appLayerId,
+            HttpServletRequest request) {
+        return proxy(
+                (GeoService gs) -> WMSService.PROTOCOL.equals(gs.getProtocol()),
+                appId,
+                appLayerId,
+                request);
+    }
+
+    public static MultiValueMap<String, String> buildOgcProxyRequestParams(
+            MultiValueMap<String, String> originalServiceParams,
+            MultiValueMap<String, String> requestParams) {
+        // Start with all the parameters from the request
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>(requestParams);
+
+        // Add original service URL parameters if they are not required OGC params
+        // (case-insensitive) and not already set by request
+        final List<String> ogcParams = List.of(new String[] {"SERVICE", "REQUEST", "VERSION"});
+        for (Map.Entry<String, List<String>> serviceParam : originalServiceParams.entrySet()) {
+            if (!params.containsKey(serviceParam.getKey())
+                    && !ogcParams.contains(serviceParam.getKey().toUpperCase())) {
+                params.put(serviceParam.getKey(), serviceParam.getValue());
+            }
+        }
+        return params;
+    }
+
+    private ResponseEntity<?> proxy(
+            Predicate<GeoService> serviceValidator,
+            Long appId,
+            Long appLayerId,
+            HttpServletRequest request) {
+
+        final Application application = applicationRepository.findById(appId).orElseThrow();
+        final ApplicationLayer appLayer =
+                applicationLayerRepository.findById(appLayerId).orElseThrow();
+        if (!authorizationService.mayUserRead(appLayer, application)) {
+            // login required, send RedirectResponse
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new RedirectResponse());
+        } else {
+            final GeoService service = appLayer.getService();
+
+            if (!serviceValidator.test(service)) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body("Invalid proxy protocol for service");
+            }
+
+            if (!Boolean.parseBoolean(
+                    String.valueOf(service.getDetails().get(GeoService.DETAIL_USE_PROXY)))) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body("Proxy not enabled for requested service");
+            }
+
+            final UriComponentsBuilder originalServiceUrl =
+                    UriComponentsBuilder.fromHttpUrl(service.getUrl());
+            final MultiValueMap<String, String> requestParams =
+                    UriComponentsBuilder.fromHttpRequest(new ServletServerHttpRequest(request))
+                            .build(true)
+                            .getQueryParams();
+            final MultiValueMap<String, String> params =
+                    buildOgcProxyRequestParams(
+                            originalServiceUrl.build(true).getQueryParams(), requestParams);
+            originalServiceUrl.replaceQueryParams(params);
+
+            return doProxy(originalServiceUrl.build(true).toUri(), service, request);
+        }
+    }
+
+    private static ResponseEntity<?> doProxy(
+            URI uri, GeoService service, HttpServletRequest request) {
+        final HttpClient.Builder builder =
+                HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL);
+
+        // Some HTTP services may not like HTTP/2 (not configurable in admin at the moment)
+        if (Boolean.parseBoolean(String.valueOf(service.getDetails().get("proxy_http1_1")))) {
+            builder.version(HttpClient.Version.HTTP_1_1);
+        }
+
+        final HttpClient httpClient = builder.build();
+
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(uri);
+
+        try {
+            String ip = request.getRemoteAddr();
+            InetAddress inetAddress = InetAddress.getByName(ip);
+
+            if (inetAddress instanceof Inet6Address) {
+                // https://stackoverflow.com/questions/33168783/
+                Inet6Address inet6Address = (Inet6Address) inetAddress;
+                int scopeId = inet6Address.getScopeId();
+
+                if (scopeId > 0) {
+                    ip = inet6Address.getHostName().replaceAll("%" + scopeId + "$", "");
+                }
+
+                // IPv6 address must be bracketed and quoted
+                ip = "\"[" + ip + "]\"";
+            }
+            requestBuilder.header("X-Forwarded-For", ip);
+            requestBuilder.header("Forwarded", "for=" + ip);
+        } catch (UnknownHostException ignored) {
+            // Don't care
+        }
+
+        // TODO: add request headers such as conditional HTTP requests
+
+        // TODO: add Basic authentication
+
+        try {
+            HttpResponse<InputStream> response =
+                    httpClient.send(
+                            requestBuilder.build(), HttpResponse.BodyHandlers.ofInputStream());
+            InputStreamResource body = new InputStreamResource(response.body());
+            org.springframework.http.HttpHeaders headers = new HttpHeaders();
+            // TODO for WMTS, does caching work?
+            String[] forwardHeaders = {
+                "Content-Type", "Content-Length", "Cache-Control", "Expires", "Pragma"
+            };
+            for (String header : forwardHeaders) {
+                headers.addAll(header, response.headers().allValues(header));
+            }
+            return ResponseEntity.status(response.statusCode()).headers(headers).body(body);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Bad Gateway");
+        }
+    }
+}

--- a/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
@@ -46,6 +46,7 @@ import java.net.UnknownHostException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -226,7 +227,9 @@ public class GeoServiceProxyController {
             String toEncode = service.getUsername() + ":" + service.getPassword();
             requestBuilder.header(
                     "Authorization",
-                    "Basic " + Base64.getEncoder().encodeToString(toEncode.getBytes()));
+                    "Basic "
+                            + Base64.getEncoder()
+                                    .encodeToString(toEncode.getBytes(StandardCharsets.UTF_8)));
         }
 
         try {

--- a/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
@@ -314,7 +314,6 @@ public class GeoServiceProxyController {
             String[] allowedResponseHeaders = {
                 "Content-Type",
                 "Content-Length",
-                "Content-Encoding",
                 "Content-Range",
                 "Content-Disposition",
                 "Cache-Control",

--- a/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
@@ -46,6 +46,7 @@ import java.net.UnknownHostException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -221,7 +222,12 @@ public class GeoServiceProxyController {
 
         // TODO: add request headers such as conditional HTTP requests
 
-        // TODO: add Basic authentication
+        if (service.getUsername() != null && service.getPassword() != null) {
+            String toEncode = service.getUsername() + ":" + service.getPassword();
+            requestBuilder.header(
+                    "Authorization",
+                    "Basic " + Base64.getEncoder().encodeToString(toEncode.getBytes()));
+        }
 
         try {
             HttpResponse<InputStream> response =

--- a/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/GeoServiceProxyController.java
@@ -262,6 +262,7 @@ public class GeoServiceProxyController {
             // authentication. This proxy sends a Forbidden response.
 
             if (!application.isAuthenticatedRequired()) {
+                // XXX for tiled services each request logs a warning, may clutter the log...
                 logger.warn(
                         String.format(
                                 "App %s has app layer %s from proxied secured service URL %s (username %s), but app authentication is not required. Denying proxy, even if user is authenticated.",

--- a/src/main/java/nl/b3p/tailormap/api/controller/MapController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/MapController.java
@@ -590,14 +590,14 @@ public class MapController {
             linkBuilder =
                     linkTo(
                             methodOn(GeoServiceProxyController.class)
-                                    .proxyWms(application.getId(), appLayer.getId(), null));
+                                    .proxy(application.getId(), appLayer.getId(), "wms", null));
         } else if (TileService.PROTOCOL.equals(geoService.getProtocol())
                 && TileService.TILING_PROTOCOL_WMTS.equals(
                         ((TileService) geoService).getTilingProtocol())) {
             linkBuilder =
                     linkTo(
                             methodOn(GeoServiceProxyController.class)
-                                    .proxyWmts(application.getId(), appLayer.getId(), null));
+                                    .proxy(application.getId(), appLayer.getId(), "wmts", null));
         } else {
             throw new IllegalArgumentException(
                     "Can't generate proxy URL for service " + geoService.getId());

--- a/src/main/java/nl/b3p/tailormap/api/controller/MapController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/MapController.java
@@ -557,8 +557,8 @@ public class MapController {
                     new Service()
                             .url(
                                     proxied
-                                            ? geoService.getUrl()
-                                            : getProxyUrl(geoService, a, applicationLayer))
+                                            ? getProxyUrl(geoService, a, applicationLayer)
+                                            : geoService.getUrl())
                             .id(geoService.getId())
                             .name(geoService.getName())
                             .protocol(Service.ProtocolEnum.fromValue(geoService.getProtocol()))

--- a/src/main/resources/tailormap-api.yaml
+++ b/src/main/resources/tailormap-api.yaml
@@ -730,3 +730,65 @@ paths:
               schema:
                 $ref: './statusresponses.yaml#/components/schemas/ErrorResponse'
 
+  /app/{appId}/layer/{layerId}/proxy/wms:
+    parameters:
+      - description: 'application id'
+        in: path
+        name: appId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - description: 'application layer id'
+        in: path
+        name: layerId
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - description: 'Must equal WMS'
+        in: query
+        name: SERVICE
+        required: true
+        schema:
+          type: string
+      - name: REQUEST
+        description: 'Either ''GetMap'' or ''GetLegendGraphic''.'
+        in: query
+        schema:
+          type: string
+        required: true
+      - name: VERSION
+        description: 'WMS version.'
+        in: query
+        schema:
+          type: string
+        required: false
+    get:
+      operationId: 'proxy'
+      description: 'Proxy a WMS request to a map service. Useful for accessing a map service requiring authentication
+         without exposing the password to the frontend. Authentication is checked by Tailormap. Additional parameters 
+         from the WMS spec may be specified which will be passed on to the original server.'
+      security:
+        - formAuth: [ ]
+      responses:
+        '200':
+          description: 'OK'
+        '400':
+          description: 'Bad Request. May be returned for some combination of parameters that can not be processed or are incomplete.'
+          content:
+            application/json:
+              schema:
+                $ref: './statusresponses.yaml#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: './statusresponses.yaml#/components/schemas/RedirectResponse'
+        '500':
+          description: 'Internal server error'
+          content:
+            application/json:
+              schema:
+                $ref: './statusresponses.yaml#/components/schemas/ErrorResponse'

--- a/src/main/resources/tailormap-api.yaml
+++ b/src/main/resources/tailormap-api.yaml
@@ -730,7 +730,7 @@ paths:
               schema:
                 $ref: './statusresponses.yaml#/components/schemas/ErrorResponse'
 
-  /app/{appId}/layer/{layerId}/proxy/wms:
+  /app/{appId}/layer/{layerId}/proxy/{protocol}:
     parameters:
       - description: 'application id'
         in: path
@@ -746,27 +746,33 @@ paths:
         schema:
           type: integer
           format: int64
-      - description: 'Must equal WMS'
+      - description: 'proxy protocol, must equal ''wmts'' or ''wms'''
+        in: path
+        name: protocol
+        required: true
+        schema:
+          type: string
+      - description: 'Must equal WMS or WMTS'
         in: query
         name: SERVICE
         required: true
         schema:
           type: string
       - name: REQUEST
-        description: 'Either ''GetMap'' or ''GetLegendGraphic''.'
+        description: 'A valid WMS/WMTS request value.'
         in: query
         schema:
           type: string
         required: true
       - name: VERSION
-        description: 'WMS version.'
+        description: 'WMS/WMTS version.'
         in: query
         schema:
           type: string
         required: false
     get:
       operationId: 'proxy'
-      description: 'Proxy a WMS request to a map service. Useful for accessing a map service requiring authentication
+      description: 'Proxy a WMS/WMTS request to a map service. Useful for accessing a map service requiring authentication
          without exposing the password to the frontend. Authentication is checked by Tailormap. Additional parameters 
          from the WMS spec may be specified which will be passed on to the original server.'
       security:
@@ -777,18 +783,36 @@ paths:
         '400':
           description: 'Bad Request. May be returned for some combination of parameters that can not be processed or are incomplete.'
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: './statusresponses.yaml#/components/schemas/ErrorResponse'
+                type: string
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: './statusresponses.yaml#/components/schemas/RedirectResponse'
+        '403':
+          description: 'Forbidden. Proxy not enabled for service or the proxy has credentials but the app is public.'
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: 'Not Found. Application or application layer does not exist or protocol is unknown.'
+          content:
+            text/plain:
+              schema:
+                type: string
         '500':
           description: 'Internal server error'
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: './statusresponses.yaml#/components/schemas/ErrorResponse'
+                type: string
+        '504':
+          description: 'Bad Gateway. Proxied service not reachable or responding.'
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/src/test/java/nl/b3p/tailormap/api/controller/GeoServiceProxyControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/GeoServiceProxyControllerPostgresIntegrationTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2022 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import nl.b3p.tailormap.api.JPAConfiguration;
+import nl.b3p.tailormap.api.security.AuthorizationService;
+import nl.b3p.tailormap.api.security.SecurityConfig;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+@SpringBootTest(
+        classes = {
+            JPAConfiguration.class,
+            GeoServiceProxyController.class,
+            SecurityConfig.class,
+            AuthorizationService.class
+        })
+@AutoConfigureMockMvc
+@EnableAutoConfiguration
+@ActiveProfiles("postgresql")
+@Execution(ExecutionMode.CONCURRENT)
+class GeoServiceProxyControllerPostgresIntegrationTest {
+    @Autowired private MockMvc mockMvc;
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void app_not_found_404() throws Exception {
+        mockMvc.perform(get("/app/1234/layer/76/proxy/wms"))
+                .andExpect(status().isNotFound())
+                .andExpect(
+                        content()
+                                .string(
+                                        "Requested an application or appLayer that does not exist"));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void deny_non_proxied_service() throws Exception {
+        mockMvc.perform(get("/app/1/layer/10/proxy/wms"))
+                .andExpect(status().isForbidden())
+                .andExpect(content().string("Proxy not enabled for requested service"));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void deny_wrong_protocol() throws Exception {
+        mockMvc.perform(get("/app/5/layer/15/proxy/wmts"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Invalid proxy protocol for service"));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void deny_http_post() throws Exception {
+        // Forbidden instead of 405 Method Not Allowed?
+        mockMvc.perform(post("/app/5/layer/15/proxy/wms")).andExpect(status().isForbidden());
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void test_pdok_wms_GetCapabilities() throws Exception {
+        mockMvc.perform(
+                        get("/app/5/layer/15/proxy/wms?REQUEST=GetCapabilities&SERVICE=WMS")
+                                .header("User-Agent", "Pietje"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_XML))
+                .andExpect(
+                        content()
+                                .string(
+                                        startsWith(
+                                                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<WMS_Capabilities")));
+    }
+
+    private static class StringIsNotZeroMatcher extends TypeSafeMatcher<String> {
+        @Override
+        protected boolean matchesSafely(String item) {
+            return Long.parseLong(item) > 0;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("is not zero");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void test_pdok_wms_GetMap() throws Exception {
+        mockMvc.perform(
+                        get(
+                                "/app/5/layer/15/proxy/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=TRUE&LAYERS=Gemeentegebied&SRS=EPSG:28992&STYLES=&WIDTH=1431&HEIGHT=1152&BBOX=5864.898958858859,340575.3140154673,283834.9241914773,564349.9255234873"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.IMAGE_PNG))
+                .andExpect(header().string("Content-Length", new StringIsNotZeroMatcher()));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void test_pdok_wms_GetLegendGraphic() throws Exception {
+        mockMvc.perform(
+                        get(
+                                "/app/5/layer/15/proxy/wms?language=dut&version=1.1.1&service=WMS&request=GetLegendGraphic&layer=Gemeentegebied&format=image/png&STYLE=Gemeentegebied&SCALE=693745.6953993673"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.IMAGE_PNG))
+                .andExpect(header().string("Content-Length", new StringIsNotZeroMatcher()));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void test_pdok_wmts_GetCapabilities() throws Exception {
+        mockMvc.perform(
+                        get(
+                                "/app/5/layer/16/proxy/wmts?Service=WMTS&Request=GetCapabilities&Version=1.0.0"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+                .andExpect(content().string(containsString("<TileMatrix")));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void test_pdok_wmts_GetTile() throws Exception {
+        mockMvc.perform(
+                        get(
+                                "/app/5/layer/16/proxy/wmts?layer=Actueel_ortho25&style=default&tilematrixset=EPSG:28992&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image/jpeg&TileMatrix=04&TileCol=8&TileRow=7"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.IMAGE_JPEG))
+                .andExpect(header().string("Content-Length", new StringIsNotZeroMatcher()))
+                .andExpect(header().exists("Last-Modified"));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void test_pdok_wmts_GetTile_Conditional() throws Exception {
+        final DateTimeFormatter httpDateHeaderFormatter =
+                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH)
+                        .withZone(ZoneId.of("GMT"));
+        mockMvc.perform(
+                        get("/app/5/layer/16/proxy/wmts?layer=Actueel_ortho25&style=default&tilematrixset=EPSG:28992&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image/jpeg&TileMatrix=04&TileCol=8&TileRow=7")
+                                .header(
+                                        "If-Modified-Since",
+                                        httpDateHeaderFormatter.format(Instant.now())))
+                .andExpect(status().isNotModified());
+    }
+}

--- a/src/test/java/nl/b3p/tailormap/api/controller/GeoServiceProxyControllerTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/GeoServiceProxyControllerTest.java
@@ -1,0 +1,48 @@
+package nl.b3p.tailormap.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/*
+ * Copyright (C) 2022 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */ class GeoServiceProxyControllerTest {
+
+    @Test
+    void buildOgcProxyRequestParams() {
+        String originalUrl = "https://service/path1?param=abc";
+        String requestUrl = "https://api/path2?request=GetMap&other=value";
+        assertEquals(
+                UriComponentsBuilder.fromHttpUrl(
+                                "https://service/path1?request=GetMap&param=abc&other=value")
+                        .build(),
+                getProxyUrl(originalUrl, requestUrl),
+                "bad proxy params");
+
+        originalUrl = "https://service/path1?param=abc&REQUEST=GetCapabilities&original=value";
+        requestUrl = "https://api/path2?request=GetMap&param=xyz";
+        assertEquals(
+                UriComponentsBuilder.fromHttpUrl(
+                                "https://service/path1?request=GetMap&param=xyz&original=value")
+                        .build(),
+                getProxyUrl(originalUrl, requestUrl),
+                "bad proxy params");
+    }
+
+    private static UriComponents getProxyUrl(String originalUrl, String requestUrl) {
+        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(originalUrl);
+        uriComponentsBuilder.replaceQueryParams(
+                GeoServiceProxyController.buildOgcProxyRequestParams(
+                        getUrlParams(originalUrl), getUrlParams(requestUrl)));
+        return uriComponentsBuilder.build();
+    }
+
+    private static MultiValueMap<String, String> getUrlParams(String url) {
+        return UriComponentsBuilder.fromHttpUrl(url).build().getQueryParams();
+    }
+}

--- a/src/test/java/nl/b3p/tailormap/api/controller/MapControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/MapControllerPostgresIntegrationTest.java
@@ -5,11 +5,24 @@
  */
 package nl.b3p.tailormap.api.controller;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.jayway.jsonpath.JsonPath;
+
 import nl.b3p.tailormap.api.JPAConfiguration;
 import nl.b3p.tailormap.api.model.Service;
 import nl.b3p.tailormap.api.security.AuthorizationService;
 import nl.b3p.tailormap.api.security.SecurityConfig;
+
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.Stopwatch;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,17 +37,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(
         classes = {
@@ -74,26 +76,30 @@ class MapControllerPostgresIntegrationTest {
                 () -> ("services array contains non-unique items: " + allSvc));
     }
 
-
     @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void should_contain_proxy_url() throws Exception {
-                mockMvc.perform(get("/app/5/map"))
-                        .andExpect(status().isOk())
-                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                        .andExpect(
-                                jsonPath("$.services[?(@.name == 'Bestuurlijke Gebieden View Service (proxied)')].url")
-                                        // Need to use contains() because jsonPath() returns an array even when the expression resolves to a single scalar property
-                                        .value(contains(endsWith("/app/5/layer/15/proxy/wms"))))
-                        .andExpect(
-                                jsonPath("$.services[?(@.name == 'PDOK HWH luchtfoto (proxied)')].url")
-                                        .value(contains(endsWith("/app/5/layer/16/proxy/wmts"))))
-                        .andExpect(
-                                jsonPath("$.appLayers[?(@.layerName === \"Gemeentegebied\")].legendImageUrl")
-                                        .value(contains(allOf(
-                                                containsString("/app/5/layer/15/proxy/wms"),
-                                                containsString("request=GetLegendGraphic"))
-                                        )))
-                        .andReturn();
+        mockMvc.perform(get("/app/5/map"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(
+                        jsonPath(
+                                        "$.services[?(@.name == 'Bestuurlijke Gebieden View Service (proxied)')].url")
+                                // Need to use contains() because jsonPath() returns an array even
+                                // when the expression resolves to a single scalar property
+                                .value(contains(endsWith("/app/5/layer/15/proxy/wms"))))
+                .andExpect(
+                        jsonPath("$.services[?(@.name == 'PDOK HWH luchtfoto (proxied)')].url")
+                                .value(contains(endsWith("/app/5/layer/16/proxy/wmts"))))
+                .andExpect(
+                        jsonPath(
+                                        "$.appLayers[?(@.layerName === \"Gemeentegebied\")].legendImageUrl")
+                                .value(
+                                        contains(
+                                                allOf(
+                                                        containsString("/app/5/layer/15/proxy/wms"),
+                                                        containsString(
+                                                                "request=GetLegendGraphic")))))
+                .andReturn();
     }
-
 }

--- a/src/test/java/nl/b3p/tailormap/api/controller/MapControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/MapControllerPostgresIntegrationTest.java
@@ -5,20 +5,11 @@
  */
 package nl.b3p.tailormap.api.controller;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.jayway.jsonpath.JsonPath;
-
 import nl.b3p.tailormap.api.JPAConfiguration;
 import nl.b3p.tailormap.api.model.Service;
 import nl.b3p.tailormap.api.security.AuthorizationService;
 import nl.b3p.tailormap.api.security.SecurityConfig;
-
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.Stopwatch;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +24,17 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(
         classes = {
@@ -71,4 +73,27 @@ class MapControllerPostgresIntegrationTest {
                 uniqueSvc.size(),
                 () -> ("services array contains non-unique items: " + allSvc));
     }
+
+
+    @Test
+    void should_contain_proxy_url() throws Exception {
+                mockMvc.perform(get("/app/5/map"))
+                        .andExpect(status().isOk())
+                        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(
+                                jsonPath("$.services[?(@.name == 'Bestuurlijke Gebieden View Service (proxied)')].url")
+                                        // Need to use contains() because jsonPath() returns an array even when the expression resolves to a single scalar property
+                                        .value(contains(endsWith("/app/5/layer/15/proxy/wms"))))
+                        .andExpect(
+                                jsonPath("$.services[?(@.name == 'PDOK HWH luchtfoto (proxied)')].url")
+                                        .value(contains(endsWith("/app/5/layer/16/proxy/wmts"))))
+                        .andExpect(
+                                jsonPath("$.appLayers[?(@.layerName === \"Gemeentegebied\")].legendImageUrl")
+                                        .value(contains(allOf(
+                                                containsString("/app/5/layer/15/proxy/wms"),
+                                                containsString("request=GetLegendGraphic"))
+                                        )))
+                        .andReturn();
+    }
+
 }


### PR DESCRIPTION
- [x] HTM-484 Basic request proxy endpoint
- [x] HTM-486 Deny proxy when not authorized
- [x] Add additional request headers (such as If-Modified-Since, Accept, etc) but not Encoding headers
- [x] HTM-485 Add HTTP Basic authentication
- [x] HTM-483 Replace URL in /map endpoint for proxied services
- [x] HTM-482 Check GetLegendGraphic works
- [x] HTM-560 Deny proxy for secured service in public app 
- [x] Check GetFeatureInfo works
- [x] Check WMTS works (WMTS capabilities has unproxied URL which is currently used for loading tile matrix sets)
- [x] Check WMTS cache headers for tiles work
- [ ] Check how much delay is added by database requests by adding timers

