### PR TITLE
HTM-625: Send starting opacity in API

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/controller/MapController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/MapController.java
@@ -460,6 +460,13 @@ public class MapController {
                 }
             }
 
+            int opacity =
+                    Optional.ofNullable(applicationLayer.getDetails().get("transparency"))
+                            .map(Object::toString)
+                            .map(Integer::parseInt)
+                            .map(transparency -> 100 - transparency)
+                            .orElse(100);
+
             AppLayer appLayer =
                     new AppLayer()
                             .id(applicationLayer.getId())
@@ -468,6 +475,7 @@ public class MapController {
                             .serviceId(applicationLayer.getService().getId())
                             .url(proxied ? getProxyUrl(geoService, a, applicationLayer) : null)
                             .visible(l.isChecked())
+                            .opacity(opacity)
                             .maxScale(serviceLayer.getMaxScale())
                             .minScale(serviceLayer.getMinScale())
                             .legendImageUrl(legendImageUrl)

--- a/src/main/resources/model.yaml
+++ b/src/main/resources/model.yaml
@@ -122,6 +122,9 @@ components:
           type: string
         visible:
           type: boolean
+        opacity:
+          description: The opacity of the layer (in percentage, from 0-100, where 0 is "transparent" and 100 is "opaque").
+          type: integer
         minScale:
           description: Minimum scale at which this layer should be shown or is not blank. When absent there is no minimum. As reported by the service (ScaleHint or MinScaleDenominator).
           type: number


### PR DESCRIPTION
(Do we want "opacity" to be sent as 0-100 instead of e.g. 0-1? The viewer uses 0-100, and persistence stores the transparency as 0-100; so it's probably fine.)