### PR TITLE
Revert "Bump dependency-check-maven from 7.4.4 to 8.0.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ SPDX-License-Identifier: MIT
     <maven-pmd-plugin.version>3.20.0</maven-pmd-plugin.version>
     <versions-maven-plugin.version>2.14.2</versions-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
-    <dependency-check-maven.version>8.0.0</dependency-check-maven.version>
+    <dependency-check-maven.version>7.4.4</dependency-check-maven.version>
     <modernizer-maven-plugin.version>2.5.0</modernizer-maven-plugin.version>
     <!-- docker.b3p.nl or alternatively ghcr.io  -->
     <docker.deploy.repo>ghcr.io</docker.deploy.repo>


### PR DESCRIPTION
Reverts B3Partners/tailormap-api#304

see also https://github.com/B3Partners/tailormap-api/pull/307#issuecomment-1396633892