### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ SPDX-License-Identifier: MIT
         mvn -U org.codehaus.mojo:versions-maven-plugin:display-plugin-updates
     to check
     -->
-        <jackson-bom.version>2.14.1</jackson-bom.version>
+        <jackson-bom.version>2.14.2</jackson-bom.version>
         <micrometer.version>1.10.3</micrometer.version>
         <!-- make sure to keep this hibernate version and that of tailormap persistence version in sync -->
         <hibernate.version>5.6.14.Final</hibernate.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@ SPDX-License-Identifier: MIT
         <hibernate.version>5.6.14.Final</hibernate.version>
         <hsqldb.version>2.7.1</hsqldb.version>
         <junit-jupiter.version>5.9.2</junit-jupiter.version>
-        <mssql-jdbc.version>11.2.3.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
         <oracle-database.version>21.8.0.0</oracle-database.version>
         <postgresql.version>42.5.1</postgresql.version>
         <snakeyaml.version>1.33</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@ SPDX-License-Identifier: MIT
         <junit-jupiter.version>5.9.2</junit-jupiter.version>
         <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
         <oracle-database.version>21.8.0.0</oracle-database.version>
-        <postgresql.version>42.5.1</postgresql.version>
+        <postgresql.version>42.5.2</postgresql.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <spring-security.version>5.8.0</spring-security.version>
         <!-- Don't upgrade these; there are some fixed dependencies on org/slf4j/impl/StaticLoggerBinder


### PR DESCRIPTION
- Bump jackson-bom.version 2.14.1 ⇨ 2.14.2
- Bump com.microsoft.sqlserver:mssql-jdbc 11.2.3.jre11 ⇨ 12.2.0.jre11
- Bump org.postgresql:postgresql 42.5.1 ⇨ 42.5.2