### PR TITLE
Add model for geo service catalog

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/configuration/TailormapDatabaseInitialization.java
+++ b/src/main/java/nl/b3p/tailormap/api/configuration/TailormapDatabaseInitialization.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package nl.b3p.tailormap.api.configuration;
+
+import java.util.List;
+import javax.annotation.PostConstruct;
+import nl.b3p.tailormap.api.persistence.Catalog;
+import nl.b3p.tailormap.api.persistence.json.CatalogNode;
+import nl.b3p.tailormap.api.repository.CatalogRepository;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
+
+@Configuration
+@Service("tailormap-database-initialization")
+public class TailormapDatabaseInitialization {
+  CatalogRepository catalogRepository;
+
+  public TailormapDatabaseInitialization(CatalogRepository catalogRepository) {
+    this.catalogRepository = catalogRepository;
+  }
+
+  @PostConstruct
+  public void databaseInitialization() {
+    Catalog catalog =
+        new Catalog()
+            .setId(Catalog.MAIN)
+            .setNodes(List.of(new CatalogNode().root(true).title("root").id("root")));
+    catalogRepository.save(catalog);
+  }
+}

--- a/src/main/java/nl/b3p/tailormap/api/configuration/dev/PopulateTestDatabase.java
+++ b/src/main/java/nl/b3p/tailormap/api/configuration/dev/PopulateTestDatabase.java
@@ -5,16 +5,20 @@
  */
 package nl.b3p.tailormap.api.configuration.dev;
 
+import java.util.List;
 import javax.annotation.PostConstruct;
 import nl.b3p.tailormap.api.persistence.Application;
 import nl.b3p.tailormap.api.persistence.Configuration;
 import nl.b3p.tailormap.api.persistence.GeoService;
+import nl.b3p.tailormap.api.persistence.GeoServiceCatalog;
 import nl.b3p.tailormap.api.persistence.helper.GeoServiceHelper;
 import nl.b3p.tailormap.api.persistence.json.AppContent;
 import nl.b3p.tailormap.api.persistence.json.AppLayerRef;
 import nl.b3p.tailormap.api.persistence.json.BaseLayerInner;
+import nl.b3p.tailormap.api.persistence.json.GeoServiceCatalogNode;
 import nl.b3p.tailormap.api.repository.ApplicationRepository;
 import nl.b3p.tailormap.api.repository.ConfigurationRepository;
+import nl.b3p.tailormap.api.repository.GeoServiceCatalogRepository;
 import nl.b3p.tailormap.api.repository.GeoServiceRepository;
 import nl.b3p.tailormap.api.viewer.model.Bounds;
 import org.apache.commons.logging.Log;
@@ -26,16 +30,19 @@ import org.springframework.context.annotation.Profile;
 public class PopulateTestDatabase {
   private static final Log log = LogFactory.getLog(PopulateTestDatabase.class);
 
+  private final GeoServiceCatalogRepository geoServiceCatalogRepository;
   private final GeoServiceRepository geoServiceRepository;
   private final GeoServiceHelper geoServiceHelper;
   private final ApplicationRepository applicationRepository;
   private final ConfigurationRepository configurationRepository;
 
   public PopulateTestDatabase(
+      GeoServiceCatalogRepository geoServiceCatalogRepository,
       GeoServiceRepository geoServiceRepository,
       GeoServiceHelper geoServiceHelper,
       ApplicationRepository applicationRepository,
       ConfigurationRepository configurationRepository) {
+    this.geoServiceCatalogRepository = geoServiceCatalogRepository;
     this.geoServiceRepository = geoServiceRepository;
     this.geoServiceHelper = geoServiceHelper;
     this.applicationRepository = applicationRepository;
@@ -49,6 +56,11 @@ public class PopulateTestDatabase {
       // Test database already initialized for integration tests
       return;
     }
+
+    GeoServiceCatalog catalog =
+        new GeoServiceCatalog()
+            .setNodes(List.of(new GeoServiceCatalogNode().root(true).title("Root").id("root")));
+    geoServiceCatalogRepository.save(catalog);
 
     String[][] services = {
       {"wms", "Test GeoServer", "https://snapshot.tailormap.nl/geoserver/wms"},

--- a/src/main/java/nl/b3p/tailormap/api/persistence/Catalog.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/Catalog.java
@@ -8,35 +8,33 @@ package nl.b3p.tailormap.api.persistence;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import nl.b3p.tailormap.api.persistence.json.GeoServiceCatalogNode;
+import nl.b3p.tailormap.api.persistence.json.CatalogNode;
 import org.hibernate.annotations.Type;
 
 @Entity
-public class GeoServiceCatalog {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+public class Catalog {
+  public static final String MAIN = "main";
+  @Id private String id;
 
   @Type(type = "io.hypersistence.utils.hibernate.type.json.JsonBinaryType")
   @Column(columnDefinition = "jsonb")
-  private List<GeoServiceCatalogNode> nodes;
+  private List<CatalogNode> nodes;
 
-  public Long getId() {
+  public String getId() {
     return id;
   }
 
-  public void setId(Long id) {
+  public Catalog setId(String id) {
     this.id = id;
+    return this;
   }
 
-  public List<GeoServiceCatalogNode> getNodes() {
+  public List<CatalogNode> getNodes() {
     return nodes;
   }
 
-  public GeoServiceCatalog setNodes(List<GeoServiceCatalogNode> nodes) {
+  public Catalog setNodes(List<CatalogNode> nodes) {
     this.nodes = nodes;
     return this;
   }

--- a/src/main/java/nl/b3p/tailormap/api/persistence/GeoServiceCatalog.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/GeoServiceCatalog.java
@@ -5,12 +5,13 @@
  */
 package nl.b3p.tailormap.api.persistence;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import nl.b3p.tailormap.api.persistence.json.GeoServiceCatalogNode;
 import org.hibernate.annotations.Type;
 
 @Entity
@@ -21,7 +22,7 @@ public class GeoServiceCatalog {
 
   @Type(type = "io.hypersistence.utils.hibernate.type.json.JsonBinaryType")
   @Column(columnDefinition = "jsonb")
-  private JsonNode services;
+  private List<GeoServiceCatalogNode> nodes;
 
   public Long getId() {
     return id;
@@ -31,11 +32,12 @@ public class GeoServiceCatalog {
     this.id = id;
   }
 
-  public JsonNode getServices() {
-    return services;
+  public List<GeoServiceCatalogNode> getNodes() {
+    return nodes;
   }
 
-  public void setServices(JsonNode services) {
-    this.services = services;
+  public GeoServiceCatalog setNodes(List<GeoServiceCatalogNode> nodes) {
+    this.nodes = nodes;
+    return this;
   }
 }

--- a/src/main/java/nl/b3p/tailormap/api/repository/CatalogRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/CatalogRepository.java
@@ -5,7 +5,7 @@
  */
 package nl.b3p.tailormap.api.repository;
 
-import nl.b3p.tailormap.api.persistence.GeoServiceCatalog;
+import nl.b3p.tailormap.api.persistence.Catalog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface GeoServiceCatalogRepository extends JpaRepository<GeoServiceCatalog, Long> {}
+public interface CatalogRepository extends JpaRepository<Catalog, String> {}

--- a/src/main/java/nl/b3p/tailormap/api/repository/GeoServiceCatalogRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/GeoServiceCatalogRepository.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2023 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.repository;
+
+import nl.b3p.tailormap.api.persistence.GeoServiceCatalog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GeoServiceCatalogRepository extends JpaRepository<GeoServiceCatalog, Long> {}

--- a/src/main/resources/openapi/persistence-schemas.yaml
+++ b/src/main/resources/openapi/persistence-schemas.yaml
@@ -15,8 +15,8 @@ paths: { }
 
 components:
   schemas:
-    GeoServiceCatalogNode:
-      description: Categorization for services.
+    CatalogNode:
+      description: Categorization for items in the catalog.
       properties:
         id:
           type: string
@@ -28,10 +28,17 @@ components:
           type: array
           items:
             type: string
-        serviceIds:
+        items:
           type: array
           items:
-            type: string
+            title: TailormapObjectRef
+            type: object
+            properties:
+              kind:
+                type: string
+                enum: ['geo-service', 'feature-source']
+              id:
+                type: string
 
     ServiceCaps:
       type: object

--- a/src/main/resources/openapi/persistence-schemas.yaml
+++ b/src/main/resources/openapi/persistence-schemas.yaml
@@ -15,6 +15,24 @@ paths: { }
 
 components:
   schemas:
+    GeoServiceCatalogNode:
+      description: Categorization for services.
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        root:
+          type: boolean
+        children:
+          type: array
+          items:
+            type: string
+        serviceIds:
+          type: array
+          items:
+            type: string
+
     ServiceCaps:
       type: object
       properties:


### PR DESCRIPTION
I think we should also have feature sources in the catalog tree. WFS services can be added to the same node as the service where they were discovered from and you can categorize them as well.

So the schema would be:

```yaml
    CatalogNode:
      description: Categorization for items in the catalog.
      properties:
        id:
          type: string
        title:
          type: string
        root:
          type: boolean
        children:
          type: array
          items:
            type: string
        items:
          type: array
          items:
            title: TailormapObjectRef
            type: object
            properties:
              kind:
                type: string
                enum: ['geo-service', 'feature-source']
              id:
                type: string
```

Maybe we can also integrate an ArcGIS REST service tree in the future.