### PR TITLE
Bump oracle-database.version from 21.8.0.0 to 21.9.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ SPDX-License-Identifier: MIT
         <hibernate.version>5.6.14.Final</hibernate.version>
         <junit-jupiter.version>5.9.2</junit-jupiter.version>
         <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
-        <oracle-database.version>21.8.0.0</oracle-database.version>
+        <oracle-database.version>21.9.0.0</oracle-database.version>
         <postgresql.version>42.5.3</postgresql.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <spring-security.version>5.8.0</spring-security.version>


### PR DESCRIPTION
Bumps ojdbc11 from 21.8.0.0 to 21.9.0.0.