### PR TITLE
Bump Hibernate from 5.6.14.Final to 5.6.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@ SPDX-License-Identifier: MIT
     -->
         <jackson-bom.version>2.14.2</jackson-bom.version>
         <micrometer.version>1.10.3</micrometer.version>
-        <hibernate.version>5.6.14.Final</hibernate.version>
+        <hibernate.version>5.6.15.Final</hibernate.version>
         <junit-jupiter.version>5.9.2</junit-jupiter.version>
         <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
         <oracle-database.version>21.9.0.0</oracle-database.version>
@@ -151,6 +151,7 @@ SPDX-License-Identifier: MIT
         <pmd.version>6.54.0</pmd.version>
         <errorProne.version>2.16</errorProne.version>
         <errorProneFlags>-XepDisableWarningsInGeneratedCode</errorProneFlags>
+        <errorProneExcludePaths>${project.build.directory}/generated-sources/.*</errorProneExcludePaths>
         <compiler.lint>deprecation,unchecked</compiler.lint>
         <failOnValidation>true</failOnValidation>
         <fmt.action>format</fmt.action>
@@ -707,7 +708,7 @@ SPDX-License-Identifier: MIT
                     <fork>true</fork>
                     <compilerArgs combine.children="append">
                         <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne -XepExcludedPaths:${project.build.directory}/generated-sources/.* ${errorProneFlags}</arg>
+                        <arg>-Xplugin:ErrorProne -XepExcludedPaths:${errorProneExcludePaths} ${errorProneFlags}</arg>
                         <arg>-Xlint:${compiler.lint}</arg>
                         <arg>-Werror</arg>
                         <arg>-Xmaxwarns</arg>
@@ -1420,6 +1421,10 @@ SPDX-License-Identifier: MIT
             </activation>
             <properties>
                 <docker.skip>true</docker.skip>
+                <!-- on windows we need to use -XepExcludedPaths:\Q${project.build.directory}\E.
+                     see https://github.com/google/error-prone/issues/2394
+                -->
+                <errorProneExcludePaths>\Q${project.build.directory}\E.*</errorProneExcludePaths>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
# Release notes - Hibernate ORM - 5.6.15

### Bug

[HHH-15618](https://hibernate.atlassian.net/browse/HHH-15618) Procedure should accept TypedParameterValue as parameter

[HHH-15665](https://hibernate.atlassian.net/browse/HHH-15665) Mariadb is missing identifier quote on SEQUENCE QUERY

[HHH-16049](https://hibernate.atlassian.net/browse/HHH-16049) Setting a property to its current value with bytecode enhancement enabled results in unnecessary SQL Update in some \(many\) cases

### Patch

[HHH-15792](https://hibernate.atlassian.net/browse/HHH-15792) Explicitly add JavaDoc to make @deprecated hint for createSQLQuery visible in Eclipse

### Improvement

[HHH-15685](https://hibernate.atlassian.net/browse/HHH-15685) Improve efficiency of Dialect lookup in Loader and HqlSqlWalker

[HHH-15690](https://hibernate.atlassian.net/browse/HHH-15690) HQLQueryPlan to have a direct reference to QueryTranslatorFactory

[HHH-15693](https://hibernate.atlassian.net/browse/HHH-15693) Introduce a fast-path access for ClassLoaderService being retrieved from ServiceRegistry

see https://hibernate.atlassian.net/projects/HHH/versions/32121/tab/release-report-all-issues