### PR TITLE
♻️ Various dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ SPDX-License-Identifier: MIT
         <junit-jupiter.version>5.9.2</junit-jupiter.version>
         <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
         <oracle-database.version>21.9.0.0</oracle-database.version>
-        <postgresql.version>42.5.3</postgresql.version>
+        <postgresql.version>42.5.4</postgresql.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <spring-security.version>5.8.1</spring-security.version>
         <!-- Don't upgrade these; there are some fixed dependencies on org/slf4j/impl/StaticLoggerBinder

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ SPDX-License-Identifier: MIT
         <oracle-database.version>21.9.0.0</oracle-database.version>
         <postgresql.version>42.5.3</postgresql.version>
         <snakeyaml.version>1.33</snakeyaml.version>
-        <spring-security.version>5.8.0</spring-security.version>
+        <spring-security.version>5.8.1</spring-security.version>
         <!-- Don't upgrade these; there are some fixed dependencies on org/slf4j/impl/StaticLoggerBinder
     <logback.version>1.4.1</logback.version>
     <slf4j.version>2.0.2</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@ SPDX-License-Identifier: MIT
         <postgresql.version>42.5.4</postgresql.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <spring-security.version>5.8.1</spring-security.version>
+        <spring-hateoas.version>1.5.3</spring-hateoas.version>
         <!-- Don't upgrade these; there are some fixed dependencies on org/slf4j/impl/StaticLoggerBinder
     <logback.version>1.4.1</logback.version>
     <slf4j.version>2.0.2</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ SPDX-License-Identifier: MIT
     to check
     -->
         <jackson-bom.version>2.14.2</jackson-bom.version>
-        <micrometer.version>1.10.3</micrometer.version>
+        <micrometer.version>1.10.4</micrometer.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <junit-jupiter.version>5.9.2</junit-jupiter.version>
         <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>


### PR DESCRIPTION
- Bump `micrometer.version` 1.10.3 ⇨ 1.10.4
- Bump `spring-security.version` 5.8.0 ⇨ 5.8.1
- Bump `postgresql.version` 42.5.3 ⇨ 42.5.4
- Bump `spring-hateoas.version` 1.5.2 ⇨ 1.5.3