### PR TITLE
Bump flyway.version: 8.5.13 ⇨ 9.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@ SPDX-License-Identifier: MIT
         <micrometer.version>1.10.4</micrometer.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <junit-jupiter.version>5.9.2</junit-jupiter.version>
+        <flyway.version>9.15.1</flyway.version>
         <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
         <oracle-database.version>21.9.0.0</oracle-database.version>
         <postgresql.version>42.5.4</postgresql.version>
@@ -1082,6 +1083,8 @@ SPDX-License-Identifier: MIT
                                         <exclude>org.geotools.jdbc:*</exclude>
                                         <exclude>org.geotools.xsd:*</exclude>
                                         <exclude>org.junit-pioneer:junit-pioneer</exclude>
+                                        <!-- lots of Jackson dependencies -->
+                                        <exclude>org.flywaydb:flyway-core</exclude>
                                     </excludes>
                                 </banTransitiveDependencies>
                             </rules>


### PR DESCRIPTION
there doesn't seem to be anything scary with this major version bump: https://flywaydb.org/documentation/learnmore/releaseNotes#9.0.1
