### PR TITLE
Bump GeoTools from 28.2 to 29-RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@ SPDX-License-Identifier: MIT
         <project.build.outputTimestamp>2023-01-20T18:37:45Z</project.build.outputTimestamp>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <geotools.version>28.2</geotools.version>
+        <geotools.version>29-RC1</geotools.version>
         <jts.version>1.19.0</jts.version>
         <spring.boot.version>${project.parent.version}</spring.boot.version>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@ SPDX-License-Identifier: MIT
         <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
         <oracle-database.version>21.9.0.0</oracle-database.version>
         <postgresql.version>42.6.0</postgresql.version>
+        <hsqldb.version>2.7.1</hsqldb.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <spring-security.version>5.8.2</spring-security.version>
         <spring-hateoas.version>1.5.4</spring-hateoas.version>
@@ -176,6 +177,12 @@ SPDX-License-Identifier: MIT
                 <groupId>org.gaul</groupId>
                 <artifactId>modernizer-maven-annotations</artifactId>
                 <version>${modernizer-maven-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <!-- override the version that comes with GeoTools and Spring boot -->
+                <groupId>org.hsqldb</groupId>
+                <artifactId>hsqldb</artifactId>
+                <version>${hsqldb.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
- [x] Bump GeoTools from 28.2 to 29-RC1

see: 
- https://github.com/geotools/geotools/releases/tag/29-RC1
