### PR TITLE
Remove `hibernate-enhance-maven-plugin` from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,12 +215,6 @@ SPDX-License-Identifier: MIT
             <artifactId>hibernate-micrometer</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.orm.tooling</groupId>
-            <artifactId>hibernate-enhance-maven-plugin</artifactId>
-            <version>${hibernate.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>
@@ -1110,7 +1104,6 @@ SPDX-License-Identifier: MIT
                                         <exclude>org.hibernate:hibernate-micrometer</exclude>
                                         <exclude>com.microsoft.sqlserver:mssql-jdbc:jar</exclude>
                                         <exclude>io.sentry:sentry-spring-boot-starter</exclude>
-                                        <exclude>org.hibernate.orm.tooling:hibernate-enhance-maven-plugin</exclude>
                                         <exclude>p6spy:p6spy:jar</exclude>
                                         <!-- basically each and every geotools module has a load of transitive dependencies -->
                                         <exclude>org.geotools:*</exclude>

--- a/src/main/java/nl/b3p/tailormap/api/security/ActuatorSecurityConfiguration.java
+++ b/src/main/java/nl/b3p/tailormap/api/security/ActuatorSecurityConfiguration.java
@@ -11,7 +11,7 @@ import nl.b3p.tailormap.api.persistence.Group;
 import nl.b3p.tailormap.api.persistence.User;
 import nl.b3p.tailormap.api.repository.GroupRepository;
 import nl.b3p.tailormap.api.repository.UserRepository;
-import org.codehaus.plexus.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
Maven plugins are build-time dependencies, not [compile scope dependencies](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope), they should not end up in the final artifact (runnable jar) of our product