### PR TITLE
[HTM-753][HTM-754] cleanup/fixup AppControllerIntegrationTest and LayerDescriptionControllerPostgresIntegrationTest

### DIFF
--- a/src/test/java/nl/b3p/tailormap/api/controller/AppControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/AppControllerIntegrationTest.java
@@ -14,6 +14,7 @@ import javax.persistence.EntityManager;
 import nl.b3p.tailormap.api.annotation.PostgresIntegrationTest;
 import nl.b3p.tailormap.api.persistence.Configuration;
 import nl.b3p.tailormap.api.repository.ConfigurationRepository;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -140,43 +141,17 @@ class AppControllerIntegrationTest {
         .andExpect(jsonPath("$.message").value("Not Found"));
   }
 
-  //  @Test
-  //  /* this test changes database content */
-  //  @Transactional
-  //  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  //  void should_return_default_lang_when_application_language_not_configured() throws Exception {
-  //    // unset language
-  //    applicationRepository.getReferenceById(1L).setLang(null);
-  //
-  //    mockMvc
-  //        .perform(get(basePath + "/app").param("appId", "1").accept(MediaType.APPLICATION_JSON))
-  //        .andExpect(status().isOk())
-  //        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-  //        .andExpect(jsonPath("$.apiVersion").value(getApiVersionFromPom()))
-  //        .andExpect(jsonPath("$.id").value(1))
-  //        .andExpect(jsonPath("$.name").value("test"))
-  //        .andExpect(jsonPath("$.version").value(1))
-  //        .andExpect(jsonPath("$.title").value("test title"))
-  //        // expect default value
-  //        .andExpect(jsonPath("$.lang").value("nl_NL"))
-  //        .andExpect(jsonPath("$.components").isArray())
-  //        .andExpect(jsonPath("$.components[0].type").value("measure"))
-  //        .andExpect(jsonPath("$.styling.primaryColor").isEmpty())
-  //        .andExpect(jsonPath("$.styling.logo").isEmpty());
-  //  }
-
-  //  @Test
-  //  /* this test changes database content */
-  //  @Order(Integer.MAX_VALUE - 1)
-  //  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  //  void should_send_401_when_application_configured() throws Exception {
-  //    applicationRepository.setAuthenticatedRequired(1L, true);
-  //
-  //    mockMvc
-  //        .perform(get(basePath + "/app").param("appId", "1").accept(MediaType.APPLICATION_JSON))
-  //        .andExpect(status().isUnauthorized())
-  //        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-  //        .andExpect(jsonPath("$.code").value(401))
-  //        .andExpect(jsonPath("$.url").value("/login"));
-  //  }
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  // TODO: implement authentication
+  @Disabled("Authentication is not yet implemented")
+  void should_send_401_when_application_configured() throws Exception {
+    String path = basePath + "/app/secured";
+    mockMvc
+        .perform(get(path).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(path)))
+        .andExpect(status().isUnauthorized())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value(401))
+        .andExpect(jsonPath("$.url").value("/login"));
+  }
 }

--- a/src/test/java/nl/b3p/tailormap/api/controller/LayerDescriptionControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/LayerDescriptionControllerPostgresIntegrationTest.java
@@ -70,36 +70,41 @@ class LayerDescriptionControllerPostgresIntegrationTest {
             jsonPath("$.attributes[?(@.name == 'relatievehoogteligging')].type").value("integer"));
   }
 
-  @Disabled("This test fails, proxying is currently not working/non-existent")
-  @Issue("https://b3partners.atlassian.net/browse/HTM-714")
+  @Disabled("This test fails, authorisation is not working/non-existent")
+  @Issue("https://b3partners.atlassian.net/browse/HTM-705")
+  // TODO: fix this test
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @WithMockUser(username = "noproxyuser")
   void test_wms_secured_app_denied() throws Exception {
-    final String path = apiBasePath + "/app/default/layer/19/describe";
+    final String path =
+        apiBasePath
+            + "/app/default/layer/lyr:snapshot-geoserver-proxied:postgis:begroeidterreindeel/describe";
     mockMvc
         .perform(get(path).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(path)))
         .andExpect(status().isUnauthorized())
         .andExpect(content().string("{\"code\":401,\"url\":\"/login\"}"));
   }
 
-  @Disabled("This test fails, proxying is currently not working/non-existent")
-  @Issue("https://b3partners.atlassian.net/browse/HTM-714")
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @WithMockUser(
-      username = "proxyuser",
-      authorities = {"ProxyGroup"})
+      username = "tm-admin",
+      authorities = {"admin"})
   void test_wms_secured_app_granted_but_no_feature_type() throws Exception {
+    final String path =
+        apiBasePath
+            + "/app/secured/layer/lyr:pdok-kadaster-bestuurlijkegebieden:Gemeentegebied/describe";
     mockMvc
-        .perform(get("/app/6/layer/21/describe"))
+        .perform(get(path).accept(MediaType.APPLICATION_JSON).with(requestPostProcessor(path)))
         .andExpect(status().isNotFound())
-        .andExpect(content().string("Layer does not have feature type"));
+        .andExpect(jsonPath("$.message").value("Layer does not have feature type"));
   }
 
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   @Disabled("TODO: test app was removed from integration dataset, restore later")
+  // TODO: fix this test
   void handles_unknown_attribute_type() throws Exception {
     // Depends on external service, may fail/change
     mockMvc


### PR DESCRIPTION
disable authenticated tests and add TODO's
some work is left behind to be done after authorisations start to work 

resolves:
- HTM-753
- HTM-754