### PR TITLE
Remove groups only used for authorization rules

### DIFF
--- a/src/main/resources/db/migration/V1__schema.sql
+++ b/src/main/resources/db/migration/V1__schema.sql
@@ -158,6 +158,4 @@
        foreign key (username) 
        references users;
 insert into groups(name, system_group, description) values ('admin', true, 'Administrators with full access');
-insert into groups(name, system_group, description) values ('app-authenticated', true, 'Users authorized for application with authentication required');
 insert into groups(name, system_group, description) values ('actuator', true, 'Users authorized for Spring Boot Actuator (monitoring and management)');
-insert into groups(name, system_group, description) values ('anonymous', true, 'Any user, even when not signed in.');

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,6 +1,5 @@
 
 insert into groups(name, system_group, description) values ('admin', true, 'Administrators with full access');
-insert into groups(name, system_group, description) values ('app-authenticated', true, 'Users authorized for application with authentication required');
 insert into groups(name, system_group, description) values ('actuator', true, 'Users authorized for Spring Boot Actuator (monitoring and management)');
 
 -- Default admin account will be created by AdminAccountCreator with a random password


### PR DESCRIPTION
No users should be assigned to these groups and no Spring Security rules should be made on them (only used in `AuthorizationService` to check against authorization rules), remove these groups from the database so they don't show up in the admin.