### PR TITLE
GeoTools up to 29.1 uses hsqldb 2.5.2, which has CVE-2022-41853, 29.2 will provide 2.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,8 @@ SPDX-License-Identifier: MIT
         <jackson-bom.version>2.15.2</jackson-bom.version>
         <micrometer.version>1.11.0</micrometer.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
+        <!-- GeoTools up to 29.1 uses hsqldb 2.5.2, which has CVE-2022-41853, 29.2 should provide 2.7.2 -->
+        <hsqldb.version>2.7.2</hsqldb.version>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
         <flyway.version>9.19.1</flyway.version>
         <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>


### PR DESCRIPTION
resolves dependency check warning for CVE-2022-41853