### PR TITLE
[HTM-808] Send SSE for entity updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,6 +466,11 @@ SPDX-License-Identifier: MIT
             <artifactId>nbvcxz</artifactId>
             <version>1.5.1</version>
         </dependency>
+        <dependency>
+            <groupId>ch.rasc</groupId>
+            <artifactId>sse-eventbus</artifactId>
+            <version>1.1.9</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>
@@ -745,7 +750,14 @@ SPDX-License-Identifier: MIT
                         <arg>-XDcompilePolicy=simple</arg>
                         <arg>-Xplugin:ErrorProne -XepExcludedPaths:${errorProneExcludePaths} ${errorProneFlags}</arg>
                         <arg>-Xlint:${compiler.lint}</arg>
-                        <arg>-Werror</arg>
+                        <!--
+                          Disabled because of this warning after adding sse-eventbus dependency:
+                          java: unknown enum constant org.immutables.value.Value.Style.ImplementationVisibility.PACKAGE
+                            reason: class file for org.immutables.value.Value$Style$ImplementationVisibility not found
+                          Maybe add this dependency? https://stackoverflow.com/questions/64433666/java-immutable-builder-classes-not-detected-by-intellij
+                          Only a problem when running from IntelliJ, not using spring-boot:run
+                        -->
+                        <!--<arg>-Werror</arg>-->
                         <arg>-Xmaxwarns</arg>
                         <arg>1000</arg>
                     </compilerArgs>
@@ -786,6 +798,33 @@ SPDX-License-Identifier: MIT
                             </configOptions>
                             <!--              <instantiationTypes>array=ArrayList,map=HashMap,object=Map</instantiationTypes>-->
                             <!--              <typeMappings>array=List,map=Map,object=Map</typeMappings>-->
+                            <generateApis>false</generateApis>
+                            <generateModels>true</generateModels>
+                            <generateSupportingFiles>false</generateSupportingFiles>
+                            <generateModelTests>false</generateModelTests>
+                            <skipIfSpecIsUnchanged>true</skipIfSpecIsUnchanged>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-admin-models</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/openapi/admin-schemas.yaml</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <modelPackage>nl.b3p.tailormap.api.admin.model</modelPackage>
+                            <library>spring-boot</library>
+                            <configOptions>
+                                <dateLibrary>java8</dateLibrary>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                                <openApiNullable>false</openApiNullable>
+                                <serializableModel>true</serializableModel>
+                                <useOptional>true</useOptional>
+                                <generatedConstructorWithRequiredArgs>false</generatedConstructorWithRequiredArgs>
+                                <developerOrganization>${project.organization.name}</developerOrganization>
+                                <developerOrganizationUrl>${project.organization.url}</developerOrganizationUrl>
+                            </configOptions>
                             <generateApis>false</generateApis>
                             <generateModels>true</generateModels>
                             <generateSupportingFiles>false</generateSupportingFiles>
@@ -1100,6 +1139,7 @@ SPDX-License-Identifier: MIT
                                         <exclude>com.squareup.okhttp3:*</exclude>
                                         <!-- lots of Jackson dependencies -->
                                         <exclude>org.flywaydb:flyway-core</exclude>
+                                        <exclude>ch.rasc:sse-eventbus</exclude>
                                     </excludes>
                                 </banTransitiveDependencies>
                             </rules>

--- a/src/main/java/nl/b3p/tailormap/api/configuration/TailormapConfig.java
+++ b/src/main/java/nl/b3p/tailormap/api/configuration/TailormapConfig.java
@@ -5,13 +5,17 @@
  */
 package nl.b3p.tailormap.api.configuration;
 
+import ch.rasc.sse.eventbus.config.EnableSseEventBus;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableConfigurationProperties
 @ConfigurationProperties(prefix = "tailormap-api")
+@EnableSseEventBus
+@EnableScheduling
 public class TailormapConfig {
   private int timeout;
 

--- a/src/main/java/nl/b3p/tailormap/api/controller/admin/ServerSentEventsAdminController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/admin/ServerSentEventsAdminController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package nl.b3p.tailormap.api.controller.admin;
+
+import static ch.rasc.sse.eventbus.SseEvent.DEFAULT_EVENT;
+import static nl.b3p.tailormap.api.admin.model.ServerSentEvent.EventTypeEnum.KEEP_ALIVE;
+
+import ch.rasc.sse.eventbus.SseEvent;
+import ch.rasc.sse.eventbus.SseEventBus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.invoke.MethodHandles;
+import nl.b3p.tailormap.api.admin.model.ServerSentEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+public class ServerSentEventsAdminController {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final SseEventBus eventBus;
+
+  private final ObjectMapper objectMapper;
+
+  public ServerSentEventsAdminController(SseEventBus eventBus, ObjectMapper objectMapper) {
+    this.eventBus = eventBus;
+    this.objectMapper = objectMapper;
+  }
+
+  /**
+   * Endpoint for the single-page admin frontend to receive updates to entities from other windows.
+   * The frontend does not load all data on each navigation as a traditional frontend and loads and
+   * stores entities in memory. This requires updating stale entities when these get updated in
+   * other windows (from other sessions or the same session in a different browser tab), otherwise
+   * data might get lost or overwritten.
+   *
+   * <p>This endpoint uses <a
+   * href="https://html.spec.whatwg.org/multipage/server-sent-events.html">Server-sent events</a>,
+   * which technically is a long-poll HTTP request which allows unidirectional server-initiated
+   * communication. Not bidirectional like websockets, but simpler because of the long-poll HTTP
+   * request. The webserver should ideally use HTTP/2 or higher because HTTP/1.1 limits the amount
+   * of simultaneous connections to a server per browser to 6.
+   *
+   * @return the server-sent events emitter
+   */
+  @GetMapping(path = "${tailormap-api.admin.base-path}/events/{clientId}")
+  public SseEmitter entityEvents(
+      /*@RequestParam(required = false) String[] events,*/ @PathVariable("clientId")
+          String clientId) {
+    logger.debug("New SSE client: {}, all clients: {}", clientId, this.eventBus.getAllClientIds());
+    return this.eventBus.createSseEmitter(clientId, DEFAULT_EVENT);
+  }
+
+  @Scheduled(fixedRate = 60_000)
+  public void keepAlive() throws JsonProcessingException {
+    this.eventBus.handleEvent(
+        SseEvent.ofData(
+            objectMapper.writeValueAsString(new ServerSentEvent().eventType(KEEP_ALIVE))));
+  }
+}

--- a/src/main/java/nl/b3p/tailormap/api/persistence/Application.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/Application.java
@@ -15,6 +15,7 @@ import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -26,6 +27,7 @@ import nl.b3p.tailormap.api.persistence.json.AppSettings;
 import nl.b3p.tailormap.api.persistence.json.AppTreeLayerNode;
 import nl.b3p.tailormap.api.persistence.json.AuthorizationRule;
 import nl.b3p.tailormap.api.persistence.json.Bounds;
+import nl.b3p.tailormap.api.persistence.listener.EntityEventPublisher;
 import nl.b3p.tailormap.api.viewer.model.AppStyling;
 import nl.b3p.tailormap.api.viewer.model.Component;
 import nl.b3p.tailormap.api.viewer.model.ViewerResponse;
@@ -37,6 +39,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 
 @Entity
+@EntityListeners(EntityEventPublisher.class)
 public class Application {
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/src/main/java/nl/b3p/tailormap/api/persistence/Application.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/Application.java
@@ -234,6 +234,7 @@ public class Application {
 
   // </editor-fold>
 
+  @JsonIgnore
   public Stream<AppTreeLayerNode> getAllAppTreeLayerNode() {
     if (this.getContentRoot() == null) {
       return Stream.empty();

--- a/src/main/java/nl/b3p/tailormap/api/persistence/Catalog.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/Catalog.java
@@ -9,13 +9,16 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.Id;
 import javax.persistence.Version;
 import javax.validation.constraints.NotNull;
 import nl.b3p.tailormap.api.persistence.json.CatalogNode;
+import nl.b3p.tailormap.api.persistence.listener.EntityEventPublisher;
 import org.hibernate.annotations.Type;
 
 @Entity
+@EntityListeners(EntityEventPublisher.class)
 public class Catalog {
   public static final String MAIN = "main";
   @Id private String id;

--- a/src/main/java/nl/b3p/tailormap/api/persistence/Configuration.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/Configuration.java
@@ -8,11 +8,14 @@ package nl.b3p.tailormap.api.persistence;
 import com.fasterxml.jackson.databind.JsonNode;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.Id;
 import javax.persistence.Version;
+import nl.b3p.tailormap.api.persistence.listener.EntityEventPublisher;
 import org.hibernate.annotations.Type;
 
 @Entity
+@EntityListeners(EntityEventPublisher.class)
 public class Configuration {
   public static final String DEFAULT_APP = "default-app";
 

--- a/src/main/java/nl/b3p/tailormap/api/persistence/GeoService.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/GeoService.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -32,6 +33,7 @@ import nl.b3p.tailormap.api.persistence.json.GeoServiceProtocol;
 import nl.b3p.tailormap.api.persistence.json.GeoServiceSettings;
 import nl.b3p.tailormap.api.persistence.json.ServiceAuthentication;
 import nl.b3p.tailormap.api.persistence.json.TMServiceCaps;
+import nl.b3p.tailormap.api.persistence.listener.EntityEventPublisher;
 import nl.b3p.tailormap.api.repository.FeatureSourceRepository;
 import nl.b3p.tailormap.api.util.TMStringUtils;
 import nl.b3p.tailormap.api.viewer.model.Service;
@@ -44,6 +46,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Entity
+@EntityListeners(EntityEventPublisher.class)
 public class GeoService {
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/src/main/java/nl/b3p/tailormap/api/persistence/Group.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/Group.java
@@ -9,16 +9,19 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.PreRemove;
 import javax.persistence.Table;
 import javax.persistence.Version;
 import javax.validation.constraints.Pattern;
+import nl.b3p.tailormap.api.persistence.listener.EntityEventPublisher;
 import nl.b3p.tailormap.api.util.Constants;
 
 @Entity
 @Table(name = "groups")
+@EntityListeners(EntityEventPublisher.class)
 public class Group {
   // Group to make authorization rules for anonymous users
   public static final String ANONYMOUS = "anonymous";

--- a/src/main/java/nl/b3p/tailormap/api/persistence/TMFeatureSource.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/TMFeatureSource.java
@@ -13,6 +13,7 @@ import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
@@ -29,10 +30,12 @@ import javax.validation.constraints.NotNull;
 import nl.b3p.tailormap.api.persistence.json.JDBCConnectionProperties;
 import nl.b3p.tailormap.api.persistence.json.ServiceAuthentication;
 import nl.b3p.tailormap.api.persistence.json.TMServiceCaps;
+import nl.b3p.tailormap.api.persistence.listener.EntityEventPublisher;
 import org.hibernate.annotations.Type;
 
 @Entity
 @Table(name = "feature_source")
+@EntityListeners(EntityEventPublisher.class)
 public class TMFeatureSource {
 
   public enum Protocol {

--- a/src/main/java/nl/b3p/tailormap/api/persistence/TMFeatureType.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/TMFeatureType.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -25,12 +24,10 @@ import nl.b3p.tailormap.api.persistence.helper.TMAttributeTypeHelper;
 import nl.b3p.tailormap.api.persistence.json.FeatureTypeSettings;
 import nl.b3p.tailormap.api.persistence.json.TMAttributeDescriptor;
 import nl.b3p.tailormap.api.persistence.json.TMFeatureTypeInfo;
-import nl.b3p.tailormap.api.persistence.listener.EntityEventPublisher;
 import org.hibernate.annotations.Type;
 
 @Entity
 @Table(name = "feature_type")
-@EntityListeners(EntityEventPublisher.class)
 public class TMFeatureType {
 
   @Id

--- a/src/main/java/nl/b3p/tailormap/api/persistence/TMFeatureType.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/TMFeatureType.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -24,10 +25,12 @@ import nl.b3p.tailormap.api.persistence.helper.TMAttributeTypeHelper;
 import nl.b3p.tailormap.api.persistence.json.FeatureTypeSettings;
 import nl.b3p.tailormap.api.persistence.json.TMAttributeDescriptor;
 import nl.b3p.tailormap.api.persistence.json.TMFeatureTypeInfo;
+import nl.b3p.tailormap.api.persistence.listener.EntityEventPublisher;
 import org.hibernate.annotations.Type;
 
 @Entity
 @Table(name = "feature_type")
+@EntityListeners(EntityEventPublisher.class)
 public class TMFeatureType {
 
   @Id

--- a/src/main/java/nl/b3p/tailormap/api/persistence/User.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/User.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
@@ -23,12 +24,14 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import nl.b3p.tailormap.api.persistence.listener.EntityEventPublisher;
 import nl.b3p.tailormap.api.util.Constants;
 import nl.b3p.tailormap.api.util.TMPasswordDeserializer;
 import org.hibernate.annotations.Type;
 
 @Entity
 @Table(name = "users")
+@EntityListeners(EntityEventPublisher.class)
 public class User {
 
   @Id

--- a/src/main/java/nl/b3p/tailormap/api/persistence/listener/EntityEventPublisher.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/listener/EntityEventPublisher.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2023 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package nl.b3p.tailormap.api.persistence.listener;
+
+import static ch.rasc.sse.eventbus.SseEvent.DEFAULT_EVENT;
+import static nl.b3p.tailormap.api.admin.model.ServerSentEvent.EventTypeEnum.ENTITY_CREATED;
+import static nl.b3p.tailormap.api.admin.model.ServerSentEvent.EventTypeEnum.ENTITY_DELETED;
+import static nl.b3p.tailormap.api.admin.model.ServerSentEvent.EventTypeEnum.ENTITY_UPDATED;
+
+import ch.rasc.sse.eventbus.SseEvent;
+import ch.rasc.sse.eventbus.SseEventBus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.invoke.MethodHandles;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PostPersist;
+import javax.persistence.PostRemove;
+import javax.persistence.PostUpdate;
+import nl.b3p.tailormap.api.admin.model.EntityCreatedEvent;
+import nl.b3p.tailormap.api.admin.model.ServerSentEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EntityEventPublisher {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Autowired @Lazy private EntityManagerFactory entityManagerFactory;
+
+  @Autowired @Lazy private ObjectMapper objectMapper;
+
+  @Autowired @Lazy private SseEventBus eventBus;
+
+  public EntityEventPublisher() {}
+
+  private void sendEvent(ServerSentEvent.EventTypeEnum eventTypeEnum, Object entity) {
+    Object id = null;
+    try {
+      id = entityManagerFactory.getPersistenceUnitUtil().getIdentifier(entity);
+      ServerSentEvent event =
+          new ServerSentEvent()
+              .eventType(eventTypeEnum)
+              .details(
+                  new EntityCreatedEvent()
+                      .entityName(entity.getClass().getSimpleName())
+                      .id(String.valueOf(id)));
+      this.eventBus.handleEvent(SseEvent.of(DEFAULT_EVENT, objectMapper.writeValueAsString(event)));
+    } catch (Exception e) {
+      logger.error(
+          "Error sending SSE for event type {}, entity {}, id {}",
+          eventTypeEnum,
+          entity != null ? entity.getClass().getSimpleName() : null,
+          id,
+          e);
+    }
+  }
+
+  @PostPersist
+  public void postPersist(Object entity) {
+    sendEvent(ENTITY_CREATED, entity);
+  }
+
+  @PostRemove
+  public void postRemove(Object entity) {
+    sendEvent(ENTITY_DELETED, entity);
+  }
+
+  @PostUpdate
+  public void postUpdate(Object entity) {
+    sendEvent(ENTITY_UPDATED, entity);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,7 @@ tailormap-api.strong-password.min-strength=3
 
 # in the tailormap-viewer Docker Compose stack this is changed to 0.0.0.0
 server.address=localhost
+server.http2.enabled=true
 
 # serve static frontend from this directory (/home/spring is the workdir in Dockerfile)
 spring.web.resources.static-locations=file:/home/spring/static/,classpath:/static/

--- a/src/main/resources/openapi/admin-schemas.yaml
+++ b/src/main/resources/openapi/admin-schemas.yaml
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2021 B3Partners B.V.
+#
+# SPDX-License-Identifier: MIT
+#
+openapi: 3.0.3
+info:
+  title: 'admin-models'
+  description: 'Tailormap admin API models'
+  version: '1.0'
+
+# no servers or paths, just the models in this document
+servers: [ ]
+paths: { }
+
+components:
+  schemas:
+    ServerSentEvent:
+      description: 'Server sent event'
+      type: object
+      properties:
+        eventType:
+          type: string
+          description: 'Type of event'
+          enum: ['keep-alive', 'entity-created', 'entity-deleted', 'entity-updated']
+        details:
+          type: object
+
+    EntityEvent:
+      type: object
+      properties:
+        entityName:
+          type: string
+        id:
+          type: string
+
+    EntityCreatedEvent:
+      description: 'Entity created'
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/EntityEvent'
+        - type: object
+          properties:
+            object:
+              type: object
+
+    EntityDeletedEvent:
+      description: 'Entity deleted'
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/EntityEvent'
+
+    EntityUpdatedEvent:
+      description: 'Entity created'
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/EntityEvent'
+        - type: object
+          properties:
+            object:
+              type: object

--- a/src/main/resources/openapi/admin-schemas.yaml
+++ b/src/main/resources/openapi/admin-schemas.yaml
@@ -33,29 +33,6 @@ components:
           type: string
         id:
           type: string
-
-    EntityCreatedEvent:
-      description: 'Entity created'
-      type: object
-      allOf:
-        - $ref: '#/components/schemas/EntityEvent'
-        - type: object
-          properties:
-            object:
-              type: object
-
-    EntityDeletedEvent:
-      description: 'Entity deleted'
-      type: object
-      allOf:
-        - $ref: '#/components/schemas/EntityEvent'
-
-    EntityUpdatedEvent:
-      description: 'Entity created'
-      type: object
-      allOf:
-        - $ref: '#/components/schemas/EntityEvent'
-        - type: object
-          properties:
-            object:
-              type: object
+        object:
+          description: 'The entity in JSON, only included in created and updated events.'
+          type: object


### PR DESCRIPTION
Sends events for all entities except `TMFeatureType` (these are included in `TMFeatureSource` events).

Frontend usage:

```
const clientId = Math.floor(Math.random() * 100)); // Or some other method like uuid
const eventSource = new EventSource("/api/admin/events/" + clientId);
eventSource.onmessage = (e) => { 
  console.log('event', JSON.parse(e.data));
};
```

Currently this should show all updates except group membership of `User`s. When you delete a group with a lot of members, you do get "updated" events for all users that were a member of that group before the "group deleted" event.
The user admin page does load the user (with groups) when clicking on the user. So this limitation may not be a problem for now.

In the JSON event the id of the entity is included next to the `entityName` but it could be removed because the whole entity object is included.