### PR TITLE
[HTM-874] factor out the superfluous `crs` parameter from the `/features` endpoint

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/geotools/TransformationUtil.java
+++ b/src/main/java/nl/b3p/tailormap/api/geotools/TransformationUtil.java
@@ -25,15 +25,17 @@ public class TransformationUtil {
    * single geometry attribute this may not be accurate.
    *
    * @param application the referenced application
-   * @param fs the feature source used in the application
+   * @param simpleFeatureSource the feature source used in the application
    * @return {@code null} when no transform is required and a valid transform otherwise
    * @throws FactoryException when the CRS cannot be decoded
    */
   public static MathTransform getTransformationToApplication(
-      @NotNull Application application, @NotNull SimpleFeatureSource fs) throws FactoryException {
+      @NotNull Application application, @NotNull SimpleFeatureSource simpleFeatureSource)
+      throws FactoryException {
     MathTransform transform = null;
     // this is the CRS of the "default geometry" attribute
-    final CoordinateReferenceSystem dataSourceCRS = fs.getSchema().getCoordinateReferenceSystem();
+    final CoordinateReferenceSystem dataSourceCRS =
+        simpleFeatureSource.getSchema().getCoordinateReferenceSystem();
     final CoordinateReferenceSystem appCRS = CRS.decode(application.getCrs());
     if (!CRS.equalsIgnoreMetadata(dataSourceCRS, appCRS)) {
       transform = CRS.findMathTransform(dataSourceCRS, appCRS);
@@ -48,15 +50,17 @@ public class TransformationUtil {
    * single geometry attribute this may not be accurate.
    *
    * @param application the referenced application
-   * @param fs the feature source used in the application
+   * @param simpleFeatureSource the feature source used in the application
    * @return {@code null} when no transform is required and a valid transform otherwise
    * @throws FactoryException when the CRS cannot be decoded
    */
   public static MathTransform getTransformationToDataSource(
-      @NotNull Application application, @NotNull SimpleFeatureSource fs) throws FactoryException {
+      @NotNull Application application, @NotNull SimpleFeatureSource simpleFeatureSource)
+      throws FactoryException {
     MathTransform transform = null;
     // this is the CRS of the "default geometry" attribute
-    final CoordinateReferenceSystem dataSourceCRS = fs.getSchema().getCoordinateReferenceSystem();
+    final CoordinateReferenceSystem dataSourceCRS =
+        simpleFeatureSource.getSchema().getCoordinateReferenceSystem();
     final CoordinateReferenceSystem appCRS = CRS.decode(application.getCrs());
     if (!CRS.equalsIgnoreMetadata(dataSourceCRS, appCRS)) {
       transform = CRS.findMathTransform(appCRS, dataSourceCRS);

--- a/src/main/resources/openapi/viewer-api.yaml
+++ b/src/main/resources/openapi/viewer-api.yaml
@@ -592,24 +592,15 @@ paths:
         required: true
         schema:
           type: string
-      - description: 'x-coordinate, assumed in the coordinate reference system of the attribute source if crs is omitted'
+      - description: 'x-coordinate, assumed in the coordinate reference system of the attribute source'
         in: query
         name: x
         required: false
         schema:
           type: number
-      - description: 'y-coordinate, assumed in the coordinate reference system of the attribute source if crs is omitted'
+      - description: 'y-coordinate, assumed in the coordinate reference system of the attribute source'
         in: query
         name: y
-        required: false
-        schema:
-          type: number
-      - description: '
-          EPSG code for the given x- and y-coodinates, the backend will transform to attribute source if required. 
-          Also the CRS to be used to reproject the hightlight gemometry if not in the same CRS as the attribute source.
-          '
-        in: query
-        name: crs
         required: false
         schema:
           type: number

--- a/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerIntegrationTest.java
@@ -49,7 +49,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @Execution(ExecutionMode.CONCURRENT)
 @Stopwatch
 @Order(1)
-class FeaturesControllerPostgresIntegrationTest {
+class FeaturesControllerIntegrationTest {
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerIntegrationTest.java
@@ -74,7 +74,7 @@ class FeaturesControllerIntegrationTest {
   private static final int begroeidterreindeelTotalCount = 3662;
   private static final int waterdeelTotalCount = 282;
   private static final int wegdeelTotalCount = 5934;
-  private static final int osm_polygonTotalCount = 102469;
+  private static final int osm_polygonTotalCount = 102467;
 
   @Value("${tailormap-api.base-path}")
   private String apiBasePath;

--- a/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerPostgresIntegrationTest.java
@@ -306,90 +306,40 @@ class FeaturesControllerPostgresIntegrationTest {
         .andExpect(jsonPath("$.features[0].attributes.ligtInLandNaam").value("Nederland"));
   }
 
-  //  /* test EPSG:28992 (RD New/Amersfoort) */
-  //  @Test
-  //  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  //  @WithMockUser(
-  //      username = "tm-admin",
-  //      authorities = {"admin"})
-  //  void should_produce_for_valid_input_pdok_betuurlijkegebieden() throws Exception {
-  //    final String url = apiBasePath + provinciesWFS;
-  //    mockMvc
-  //        .perform(
-  //            get(url)
-  //                .accept(MediaType.APPLICATION_JSON)
-  //                .with(setServletPath(url))
-  //                .param("x", "141247")
-  //                .param("y", "458118")
-  //                .param("simplify", "true"))
-  //        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-  //        .andExpect(status().isOk())
-  //        .andExpect(jsonPath("$.features").isArray())
-  //        .andExpect(jsonPath("$.features[0]").isMap())
-  //        .andExpect(jsonPath("$.features[0]").isNotEmpty())
-  //        .andExpect(jsonPath("$.features[0].__fid").isNotEmpty())
-  //        .andExpect(jsonPath("$.features[0].geometry").isNotEmpty())
-  //        .andExpect(jsonPath("$.features[0].attributes.naam").value("Utrecht"))
-  //        .andExpect(jsonPath("$.features[0].attributes.ligtInLandNaam").value("Nederland"));
-  //  }
+  @Test
+  @WithMockUser(
+      username = "tm-admin",
+      authorities = {"admin"})
+  void should_produce_for_valid_input_pdok_betuurlijkegebieden_without_simplifying()
+      throws Exception {
+    final String url = apiBasePath + provinciesWFS;
+    MvcResult result =
+        mockMvc
+            .perform(
+                get(url)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .with(setServletPath(url))
+                    .param("x", "141247")
+                    .param("y", "458118")
+                    .param("simplify", "false")
+                    .param("geometryInAttributes", "true"))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.features").isArray())
+            .andExpect(jsonPath("$.features[0]").isMap())
+            .andExpect(jsonPath("$.features[0]").isNotEmpty())
+            .andExpect(jsonPath("$.features[0].__fid").isNotEmpty())
+            .andExpect(jsonPath("$.features[0].geometry").isNotEmpty())
+            .andExpect(jsonPath("$.features[0].attributes.naam").value("Utrecht"))
+            .andExpect(jsonPath("$.features[0].attributes.ligtInLandNaam").value("Nederland"))
+            .andReturn();
 
-  //  /* test EPSG:3857 (web mercator) */
-  //  @Test
-  //  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  //  @WithMockUser(
-  //      username = "tm-admin",
-  //      authorities = {"admin"})
-  //  void should_produce_for_valid_input_with_alien_crs_pdok_betuurlijkegebieden() throws Exception
-  // {
-  //    final String url = apiBasePath + provinciesWFS;
-  //    mockMvc
-  //        .perform(
-  //            get(url)
-  //                .accept(MediaType.APPLICATION_JSON)
-  //                .with(setServletPath(url))
-  //                .param("x", "577351")
-  //                .param("y", "6820242")
-  //                .param("simplify", "true"))
-  //        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-  //        .andExpect(status().isOk())
-  //        .andExpect(jsonPath("$.features").isArray())
-  //        .andExpect(jsonPath("$.features[0]").isMap())
-  //        .andExpect(jsonPath("$.features[0]").isNotEmpty())
-  //        .andExpect(jsonPath("$.features[0].__fid").isNotEmpty())
-  //        .andExpect(jsonPath("$.features[0].geometry").isNotEmpty())
-  //        .andExpect(jsonPath("$.features[0].attributes.naam").value("Utrecht"))
-  //        .andExpect(jsonPath("$.features[0].attributes.ligtInLandNaam").value("Nederland"));
-  //  }
-  //
-  //  /* test EPSG:4326 (WGS84) */
-  //  @Test
-  //  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  //  @WithMockUser(
-  //      username = "tm-admin",
-  //      authorities = {"admin"})
-  //  void should_produce_for_valid_input_with_alien_crs_2_pdok_betuurlijkegebieden() throws
-  // Exception {
-  //    final String url = apiBasePath + provinciesWFS;
-  //    mockMvc
-  //        .perform(
-  //            get(url)
-  //                .accept(MediaType.APPLICATION_JSON)
-  //                .with(setServletPath(url))
-  //                // note flipped axis
-  //                .param("y", "5.04173")
-  //                .param("x", "52.11937")
-  //                .param("simplify", "true")
-  //                .param("distance", /*~ 4 meter*/ "0.00004"))
-  //        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-  //        .andExpect(status().isOk())
-  //        .andExpect(jsonPath("$.features").isArray())
-  //        .andExpect(jsonPath("$.features[0]").isMap())
-  //        .andExpect(jsonPath("$.features[0]").isNotEmpty())
-  //        .andExpect(jsonPath("$.features[0].__fid").isNotEmpty())
-  //        .andExpect(jsonPath("$.features[0].geometry").isNotEmpty())
-  //        .andExpect(jsonPath("$.features[0].attributes.naam").value("Utrecht"))
-  //        .andExpect(jsonPath("$.features[0].attributes.ligtInLandNaam").value("Nederland"));
-  //  }
+    String body = result.getResponse().getContentAsString();
+    String geometry = JsonPath.parse(body).read("$.features[0].geometry").toString();
+    String geomAttribute = JsonPath.parse(body).read("$.features[0].attributes.geom").toString();
+    assertEquals(
+        geometry, geomAttribute, "geometry and geom attribute should be equal when not simplified");
+  }
 
   /**
    * request 2 pages data from the bestuurlijke gebieden WFS featuretype provincies.

--- a/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerPostgresIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/FeaturesControllerPostgresIntegrationTest.java
@@ -87,17 +87,13 @@ class FeaturesControllerPostgresIntegrationTest {
   @Value("${tailormap-api.pageSize}")
   private int pageSize;
 
-  static Stream<Arguments> argumentsProvider() {
+  static Stream<Arguments> databaseArgumentsProvider() {
     return Stream.of(
         // docker host,table,url, feature count
-        arguments(
-            "postgis",
-            "begroeidterreindeel",
-            begroeidterreindeelUrlPostgis,
-            begroeidterreindeelTotalCount),
-        arguments("oracle", "waterdeel", waterdeelUrlOracle, waterdeelTotalCount),
-        arguments("sqlserver", "wegdeel", wegdeelUrlSqlserver, wegdeelTotalCount),
-        arguments("postgis", "osm_polygon", osm_polygonUrlPostgis, osm_polygonTotalCount));
+        arguments(begroeidterreindeelUrlPostgis, begroeidterreindeelTotalCount),
+        arguments(waterdeelUrlOracle, waterdeelTotalCount),
+        arguments(wegdeelUrlSqlserver, wegdeelTotalCount),
+        arguments(osm_polygonUrlPostgis, osm_polygonTotalCount));
   }
 
   static Stream<Arguments> differentFeatureSourcesProvider() {
@@ -211,10 +207,8 @@ class FeaturesControllerPostgresIntegrationTest {
         // or w/ 3 expressions
         arguments(
             begroeidterreindeelUrlPostgis,
-            // creationdate > '2016-04-18T00:00:00Z' or lv_publicatiedatum <
-            // '2019-11-20T17:09:52Z' or lv_publicatiedatum > '2022-01-27T13:50:39Z'
             "creationdate after 2016-04-18T00:00:00Z or lv_publicatiedatum before 2019-11-20T17:09:52Z or lv_publicatiedatum after 2022-01-27T13:50:39Z",
-            // Depends on timezone, this is for Europe/Amsterdam. For UTC 3522.
+            // value depends on timezone, this is for Europe/Amsterdam. For UTC it is 3522.
             3518),
         arguments(
             waterdeelUrlOracle,
@@ -227,10 +221,8 @@ class FeaturesControllerPostgresIntegrationTest {
         // and w/ 2 expressions
         arguments(
             begroeidterreindeelUrlPostgis,
-            // creationdate > '2016-04-18T00:00:00Z' and lv_publicatiedatum <
-            // '2019-11-20T17:09:52Z'
             "creationdate after 2016-04-18T00:00:00Z and lv_publicatiedatum before 2019-11-20T17:09:52Z",
-            // Depends on timezone, this is for Europe/Amsterdam. For UTC 1264.
+            // value depends on timezone, this is for Europe/Amsterdam. For UTC it is 1264.
             1271),
         arguments(
             waterdeelUrlOracle,
@@ -238,10 +230,8 @@ class FeaturesControllerPostgresIntegrationTest {
             77),
         arguments(
             wegdeelUrlSqlserver,
-            // creationdate > '2016-04-18T00:00:00Z' and lv_publicatiedatum <
-            // '2019-11-20T17:09:52Z'
             "creationdate after 2016-04-18T00:00:00Z and lv_publicatiedatum before 2019-11-20T17:09:52Z",
-            // Depends on timezone, this is for Europe/Amsterdam. For UTC 1933.
+            // value depends on timezone, this is for Europe/Amsterdam. For UTC it is 1933.
             1963),
         // (not) like / ilike
         arguments(begroeidterreindeelUrlPostgis, "class like 'grasland%'", 85),
@@ -788,13 +778,12 @@ class FeaturesControllerPostgresIntegrationTest {
   @ParameterizedTest(
       name =
           "#{index}: should return non-empty featurecollections for valid page from database: {0}, featuretype: {1}")
-  @MethodSource("argumentsProvider")
+  @MethodSource("databaseArgumentsProvider")
   @WithMockUser(
       username = "tm-admin",
       authorities = {"admin"})
   void should_return_non_empty_featurecollections_for_valid_pages_from_database(
-      String ignoredDatabase, String ignoredTableName, String applayerUrl, int totalCcount)
-      throws Exception {
+      String applayerUrl, int totalCcount) throws Exception {
     applayerUrl = apiBasePath + applayerUrl;
     // page 1
     MvcResult result =
@@ -995,13 +984,12 @@ class FeaturesControllerPostgresIntegrationTest {
   @ParameterizedTest(
       name =
           "#{index}: should return same featurecollection for same page from database: {0}, featuretype: {1}")
-  @MethodSource("argumentsProvider")
+  @MethodSource("databaseArgumentsProvider")
   @WithMockUser(
       username = "tm-admin",
       authorities = {"admin"})
   void should_return_same_featurecollection_for_same_page_database(
-      String ignoredDatabase, String ignoredTableName, String applayerUrl, int totalCcount)
-      throws Exception {
+      String applayerUrl, int totalCcount) throws Exception {
     applayerUrl = apiBasePath + applayerUrl;
 
     // page 1
@@ -1073,14 +1061,13 @@ class FeaturesControllerPostgresIntegrationTest {
    */
   @ParameterizedTest(
       name =
-          "#{index}: should return empty featurecollection for out of range page from database: {0}, featuretype: {1}")
-  @MethodSource("argumentsProvider")
+          "#{index}: should return empty featurecollection for out of range page from database for layer: {0}")
+  @MethodSource("databaseArgumentsProvider")
   @WithMockUser(
       username = "tm-admin",
       authorities = {"admin"})
   void should_return_empty_featurecollection_for_out_of_range_page_database(
-      String ignoredDatabase, String ignoredTableName, String applayerUrl, int totalCcount)
-      throws Exception {
+      String applayerUrl, int totalCcount) throws Exception {
     applayerUrl = apiBasePath + applayerUrl;
     // request page ...
     int page = (totalCcount / pageSize) + 5;

--- a/src/test/java/nl/b3p/tailormap/api/controller/GeoServiceProxyControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/GeoServiceProxyControllerIntegrationTest.java
@@ -36,7 +36,7 @@ import org.springframework.test.web.servlet.ResultActions;
 @PostgresIntegrationTest
 @AutoConfigureMockMvc
 @Execution(ExecutionMode.CONCURRENT)
-class GeoServiceProxyControllerPostgresIntegrationTest {
+class GeoServiceProxyControllerIntegrationTest {
   private final String begroeidterreindeelUrl =
       "/app/default/layer/lyr:snapshot-geoserver-proxied:postgis:begroeidterreindeel/proxy/wms";
 

--- a/src/test/java/nl/b3p/tailormap/api/controller/LayerDescriptionControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/LayerDescriptionControllerIntegrationTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @PostgresIntegrationTest
 @AutoConfigureMockMvc
 @Execution(ExecutionMode.CONCURRENT)
-class LayerDescriptionControllerPostgresIntegrationTest {
+class LayerDescriptionControllerIntegrationTest {
   @Autowired private MockMvc mockMvc;
 
   @Value("${tailormap-api.base-path}")

--- a/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/UniqueValuesControllerIntegrationTest.java
@@ -39,7 +39,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -47,9 +46,8 @@ import org.springframework.test.web.servlet.MvcResult;
 @AutoConfigureMockMvc
 @Execution(ExecutionMode.CONCURRENT)
 @Stopwatch
-@TestPropertySource(properties = {"tailormap-api.unique.use_geotools_unique_function=false"})
-@Order(2)
-class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
+@Order(1)
+class UniqueValuesControllerIntegrationTest {
   private static final String provinciesWFSUrl =
       "/app/default/layer/lyr:pdok-kadaster-bestuurlijkegebieden:Provinciegebied/unique/naam";
   private static final String begroeidterreindeelPostgisUrl =
@@ -96,6 +94,32 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
 
     assertEquals(values.size(), uniqueValues.size(), "Unique values should be unique");
     assertTrue(uniqueValues.containsAll(Set.of(expected)), "not all values are present");
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void layer_without_featuretype() throws Exception {
+    final String url =
+        apiBasePath
+            + "/app/default/layer/lyr:pdok-kadaster-bestuurlijkegebieden:Gemeentegebied/unique/naam";
+    mockMvc
+        .perform(get(url).accept(MediaType.APPLICATION_JSON).with(setServletPath(url)))
+        .andExpect(status().is4xxClientError())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.message").value("Layer does not have feature type"));
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void attribute_name_required() throws Exception {
+    final String url =
+        apiBasePath
+            + "/app/default/layer/lyr:pdok-kadaster-bestuurlijkegebieden:Gemeentegebied/unique/ ";
+    mockMvc
+        .perform(get(url).accept(MediaType.APPLICATION_JSON).with(setServletPath(url)))
+        .andExpect(status().is4xxClientError())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.message").value("Attribute name is required"));
   }
 
   @ParameterizedTest(
@@ -253,6 +277,31 @@ class UniqueValuesControllerReConfiguredPostgresIntegrationTest {
         .andExpect(jsonPath("$.values[1]").value(Matchers.containsString("-Holland")));
   }
 
+  /**
+   * Testcase for <a href="https://b3partners.atlassian.net/browse/HTM-492">HTM-492</a> where
+   * Jackson fails to process oracle.sql.TIMESTAMP.
+   *
+   * <p>The exception is: {@code org.springframework.web.util.NestedServletException: Request
+   * processing failed; nested exception is java.lang.ClassCastException: class oracle.sql.TIMESTAMP
+   * cannot be cast to class java.lang.Comparable (oracle.sql.TIMESTAMP is in unnamed module of
+   * loader 'app'; java.lang.Comparable is in module java.base of loader 'bootstrap') }
+   *
+   * <p>For this testcase to go green set the environment variable {@code
+   * -Doracle.jdbc.J2EE13Compliant=true}
+   *
+   * <p>See also:
+   *
+   * <ul>
+   *   <li><a
+   *       href="https://stackoverflow.com/questions/13269564/java-lang-classcastexception-oracle-sql-timestamp-cannot-be-cast-to-java-sql-ti">java.lang.ClassCastException:
+   *       oracle.sql.TIMESTAMP cannot be cast to java.sql.Timestamp</a>
+   *   <li><a
+   *       href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/accessing-and-manipulating-Oracle-data.html#GUID-C23007CA-E25D-4747-A3C0-4DE219AF56BD">Accessing
+   *       and Manipulating Oracle Data</a>
+   * </ul>
+   *
+   * @throws Exception if any
+   */
   @Issue("https://b3partners.atlassian.net/browse/HTM-492")
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")

--- a/src/test/java/nl/b3p/tailormap/api/controller/ViewerControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/ViewerControllerIntegrationTest.java
@@ -42,7 +42,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @AutoConfigureMockMvc
 @Stopwatch
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class ViewerControllerPostgresIntegrationTest {
+class ViewerControllerIntegrationTest {
   @Autowired ApplicationRepository applicationRepository;
   @Autowired private MockMvc mockMvc;
 


### PR DESCRIPTION
the `crs` parameter is actually useless since #358 and the behaviour is inconsistent with the `edit/feature` endpoint that is agnostic to application crs.

Also cleanup unused code and rename PostgresIntegrationTest to IntegrationTest as all integration tests use PostgreSQL...

resolves HTM-874
