### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ SPDX-License-Identifier: MIT
         <postgresql.version>42.6.0</postgresql.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security.version>5.8.4</spring-security.version>
-        <spring-hateoas.version>1.5.4</spring-hateoas.version>
+        <spring-hateoas.version>1.5.5</spring-hateoas.version>
         <!-- Don't upgrade these; there are some fixed dependencies on org/slf4j/impl/StaticLoggerBinder
         <logback.version>1.4.1</logback.version>
         <slf4j.version>2.0.2</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ SPDX-License-Identifier: MIT
         <!-- GeoTools up to 29.1 uses hsqldb 2.5.2, which has CVE-2022-41853, 29.2 should provide 2.7.2 -->
         <hsqldb.version>2.7.2</hsqldb.version>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
-        <flyway.version>9.19.1</flyway.version>
+        <flyway.version>9.20.1</flyway.version>
         <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
         <oracle-database.version>23.2.0.0</oracle-database.version>
         <postgresql.version>42.6.0</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ SPDX-License-Identifier: MIT
         to check
         -->
         <jackson-bom.version>2.15.2</jackson-bom.version>
-        <micrometer.version>1.11.1</micrometer.version>
+        <micrometer.version>1.11.2</micrometer.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- GeoTools up to 29.1 uses hsqldb 2.5.2, which has CVE-2022-41853, 29.2 should provide 2.7.2 -->
         <hsqldb.version>2.7.2</hsqldb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ SPDX-License-Identifier: MIT
         <!-- GeoTools up to 29.1 uses hsqldb 2.5.2, which has CVE-2022-41853, 29.2 should provide 2.7.2 -->
         <hsqldb.version>2.7.2</hsqldb.version>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
-        <flyway.version>9.20.1</flyway.version>
+        <flyway.version>9.19.1</flyway.version>
         <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
         <oracle-database.version>23.2.0.0</oracle-database.version>
         <postgresql.version>42.6.0</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
         <oracle-database.version>23.2.0.0</oracle-database.version>
         <postgresql.version>42.6.0</postgresql.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <spring-security.version>5.8.4</spring-security.version>
+        <spring-security.version>5.8.5</spring-security.version>
         <spring-hateoas.version>1.5.5</spring-hateoas.version>
         <!-- Don't upgrade these; there are some fixed dependencies on org/slf4j/impl/StaticLoggerBinder
         <logback.version>1.4.1</logback.version>


### PR DESCRIPTION
- Bump io.micrometer:micrometer-registry-prometheus 1.11.1 -> 1.11.2
- ~~Bump org.flywaydb:flyway-core 9.19.1 -> 9.20.1~~ incompatible API change
- Bump org.springframework.hateoas:spring-hateoas 1.5.4 -> 1.5.5
- Bump org.springframework.security:spring-security-test ..... 5.8.4 -> 5.8.5

Dependencies resolved:
- CVE-2023-34034
- CVE-2023-34035