### PR TITLE
[HTM-895] only set writable-true on JDBC-protocol featuretypes

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/geotools/featuresources/FeatureSourceHelper.java
+++ b/src/main/java/nl/b3p/tailormap/api/geotools/featuresources/FeatureSourceHelper.java
@@ -121,7 +121,8 @@ public abstract class FeatureSourceHelper {
                         new TMFeatureType()
                             .setName(typeName)
                             .setFeatureSource(tmfs)
-                            .setWriteable(true)); // TODO set writeable meaningfully
+                            // TODO set writeable meaningfully
+                            .setWriteable(tmfs.getProtocol() == TMFeatureSource.Protocol.JDBC));
         if (!tmfs.getFeatureTypes().contains(pft)) {
           tmfs.getFeatureTypes().add(pft);
         }


### PR DESCRIPTION
and not on all featuretypes