### PR TITLE
Revert "Bump io.fabric8:docker-maven-plugin from 0.43.0 to 0.43.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@ SPDX-License-Identifier: MIT
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.43.2</version>
+                    <version>0.43.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-scm-publish-plugin</artifactId>


### PR DESCRIPTION
Reverts B3Partners/tailormap-api#546

because of https://github.com/fabric8io/docker-maven-plugin/issues/1698