### PR TITLE
Add environment variable for hashed admin password

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,11 @@ tailormap-api.admin.base-path=/api/admin
 
 tailormap-api.security.admin.create-if-not-exists=true
 tailormap-api.security.admin.username=tm-admin
+# A hashed password can be specified in the ADMIN_HASHED_PASSWORD environment variable. If empty or not specified a
+# random password will be generated and logged.
+# If the admin account already exists the hashed password will /not/ be updated with this value.
+# This value is only used if it starts with "{bcrypt}". Use the Spring Boot CLI to hash a password.
+tailormap-api.security.admin.hashed-password=${ADMIN_HASHED_PASSWORD:#{null}}
 
 # connect and read timeout for external services (wms, wmts, wfs, jdbc)
 tailormap-api.timeout=5000


### PR DESCRIPTION
This variable was already available in the `populate-testdata` Spring profile but is useful in general too.