### PR TITLE
Use ordered (configured or original order) where appropriate

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/controller/FeaturesController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/FeaturesController.java
@@ -7,7 +7,6 @@ package nl.b3p.tailormap.api.controller;
 
 import static nl.b3p.tailormap.api.persistence.helper.TMAttributeTypeHelper.isGeometry;
 import static nl.b3p.tailormap.api.persistence.helper.TMFeatureTypeHelper.getConfiguredAttributes;
-import static nl.b3p.tailormap.api.persistence.helper.TMFeatureTypeHelper.getNonHiddenAttributes;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
@@ -178,7 +177,8 @@ public class FeaturesController implements Constants {
 
       // Property names for query: only non-geometry attributes that aren't hidden
       List<String> propNames =
-          getNonHiddenAttributes(tmft).stream()
+          getConfiguredAttributes(tmft).values().stream()
+              .map(Pair::getLeft)
               .filter(a -> !isGeometry(a.getType()))
               .map(TMAttributeDescriptor::getName)
               .collect(Collectors.toList());

--- a/src/main/java/nl/b3p/tailormap/api/controller/LayerExportController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/LayerExportController.java
@@ -5,7 +5,7 @@
  */
 package nl.b3p.tailormap.api.controller;
 
-import static nl.b3p.tailormap.api.persistence.helper.TMFeatureTypeHelper.getNonHiddenAttributeNames;
+import static nl.b3p.tailormap.api.persistence.helper.TMFeatureTypeHelper.getConfiguredAttributes;
 import static nl.b3p.tailormap.api.util.HttpProxyUtil.passthroughResponseHeaders;
 
 import io.micrometer.core.annotation.Timed;
@@ -122,7 +122,8 @@ public class LayerExportController {
       throw new ResponseStatusException(
           HttpStatus.SERVICE_UNAVAILABLE, "No suitable WFS available for layer export");
     } else {
-      Set<String> nonHiddenAttributes = getNonHiddenAttributeNames(tmft);
+      // Get attributes in configured or original order
+      Set<String> nonHiddenAttributes = getConfiguredAttributes(tmft).keySet();
 
       if (attributes == null) {
         attributes = Collections.emptyList();


### PR DESCRIPTION
`FeaturesController` sorts by first attribute if no primary key, but using unsorted attribute names made this unpredicate and sometimes cause the `FeaturesControllerIntegrationTest.should_return_non_empty_featurecollections_for_valid_page_from_wfs()` test fail because one time the first attribute would be `naam` but sometimes it would be `code`.