### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ SPDX-License-Identifier: MIT
         <flyway.version>9.22.3</flyway.version>
         <mssql-jdbc.version>12.4.1.jre11</mssql-jdbc.version>
         <oracle-database.version>23.3.0.23.09</oracle-database.version>
-        <postgresql.version>42.7.0</postgresql.version>
+        <postgresql.version>42.7.1</postgresql.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security.version>5.8.8</spring-security.version>
         <spring-hateoas.version>1.5.5</spring-hateoas.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ SPDX-License-Identifier: MIT
         <postgresql.version>42.7.1</postgresql.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security.version>5.8.8</spring-security.version>
-        <spring-hateoas.version>1.5.5</spring-hateoas.version>
+        <spring-hateoas.version>1.5.6</spring-hateoas.version>
         <!-- Don't upgrade these; there are some fixed dependencies on org/slf4j/impl/StaticLoggerBinder
         <logback.version>1.4.1</logback.version>
         <slf4j.version>2.0.2</slf4j.version>


### PR DESCRIPTION
 - [x] Bump org.postgresql:postgresql from 42.7.0 to 42.7.1
 - [x] Bump org.springframework.hateoas:spring-hateoas from 1.5.5 to 1.5.6
 - [ ] ~~Bump org.flywaydb:flyway-core from 9.22.3 to 10.1.0~~ requires Java 17