### PR TITLE
Use NVD API key from environment

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -30,7 +30,9 @@ jobs:
 
       - name: OWASP Dependency Check
         continue-on-error: true
-        run: mvn -U package -DskipTests -DskipITs -Ddocker.skip=true org.owasp:dependency-check-maven:check -fae -B -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN -DfailBuildOnCVSS=5 -DnvdApiKey=${{ secrets.NVD_API_KEY }}
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: mvn -U package -DskipTests -DskipITs -Ddocker.skip=true org.owasp:dependency-check-maven:check -fae -B -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN -DfailBuildOnCVSS=5
 
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -47,7 +47,9 @@ jobs:
         run: mvn javadoc:javadoc
 
       - name: Build Maven site
-        run: mvn site -DnvdApiKey=${{ secrets.NVD_API_KEY }}
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: mvn site
 
       - name: Archive Maven Site
         if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') }}

--- a/pom.xml
+++ b/pom.xml
@@ -982,6 +982,7 @@ SPDX-License-Identifier: MIT
                     <suppressionFile>${project.basedir}/build/qa/owasp-suppression.xml</suppressionFile>
                     <hintsFile>${project.basedir}/build/qa/owasp-hints.xml</hintsFile>
                     <format>ALL</format>
+                    <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
                 </configuration>
             </plugin>
             <plugin>
@@ -1396,6 +1397,7 @@ SPDX-License-Identifier: MIT
                 <version>${dependency-check-maven.version}</version>
                 <configuration>
                     <name>OWASP Dependency Check</name>
+                    <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
When doing `mvn release:perform`, NVD download is very slow with 8s between downloads instead of 2s without an API key, but running `mvn -DnvdApiKey=... release:perform` does not seem to provide the API key. Setting it in the environment before running `mvn release:perform` with this config should work.