### PR TITLE
Bump logback.version override from 1.2.12 to 1.2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@ SPDX-License-Identifier: MIT
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security.version>5.8.8</spring-security.version>
         <spring-hateoas.version>1.5.6</spring-hateoas.version>
+        <logback.version>1.2.13</logback.version>
         <!-- Don't upgrade these; there are some fixed dependencies on org/slf4j/impl/StaticLoggerBinder
         <logback.version>1.4.1</logback.version>
         <slf4j.version>2.0.2</slf4j.version>


### PR DESCRIPTION
Logback resolved CVE-2023-6378 and CVE-2023-6481