### PR TITLE
HTM-974: Only list additional crses in child layers to save space

### DIFF
--- a/src/test/resources/wms/test_capabilities_updated.xml
+++ b/src/test/resources/wms/test_capabilities_updated.xml
@@ -39,22 +39,20 @@
         <Layer>
             <Title>Test Layer 1</Title>
             <SRS>EPSG:28992</SRS>
-            <SRS>EPSG:3857</SRS>
-            <SRS>EPSG:4326</SRS>
             <SRS>EPSG:900913</SRS>
             <Layer cascaded="1" queryable="0">
                 <Name>Layer2</Name>
                 <Title>Test Layer 2</Title>
                 <BoundingBox SRS="EPSG:28992" minx="-285401.920000" miny="22598.080000" maxx="595401.920000"
                              maxy="903401.920000"></BoundingBox>
-                <SRS>EPSG:28992</SRS>
+                <SRS>EPSG:3857</SRS>
             </Layer>
             <Layer cascaded="1" queryable="0">
                 <Name>Layer3</Name>
                 <Title>Test Layer 3</Title>
                 <BoundingBox SRS="EPSG:28992" minx="-285401.920000" miny="22598.080000" maxx="595401.920000"
                              maxy="903401.920000"></BoundingBox>
-                <SRS>EPSG:28992</SRS>
+                <SRS>EPSG:4326</SRS>
             </Layer>
         </Layer>
     </Capability>


### PR DESCRIPTION
This should fix slow performance with the default GeoServer settings with all CRSes enabled with quite a few layers considerably. Loading/refreshing the service and proxied requests were very slow because very large JSON needed to be loaded every time with all supported CRSes repeated for every layer.

In this change only new CRSes for child layers are added to the `crs` array. We were not using this `crs` array for anything yet, so new code should take into account that all `crs` values from parent layers are inherited.