### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/macos-maven.yml
+++ b/.github/workflows/macos-maven.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: setup-java-Linux-maven-${{ hashFiles('**/pom.xml') }}
@@ -39,7 +39,7 @@ jobs:
           mvn -B -fae -e test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
 
       - name: Cleanup snapshots
         run: |

--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -39,7 +39,7 @@ jobs:
           mvn -B -fae -e test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           verbose: true
 
@@ -108,7 +108,7 @@ jobs:
             target/failsafe-reports/TEST-*.xml       
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           verbose: true
 
@@ -253,7 +253,7 @@ jobs:
     needs: [ build, publish, postgresql-test ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/cache@v4
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: setup-java-Linux-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/windows-maven.yml
+++ b/.github/workflows/windows-maven.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: setup-java-Linux-maven-${{ hashFiles('**/pom.xml') }}
@@ -40,7 +40,7 @@ jobs:
           mvn --% -e -fae -B clean test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
 
       - name: Cleanup build artifacts and snapshots
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ SPDX-License-Identifier: MIT
         <oracle-database.version>23.3.0.23.09</oracle-database.version>
         <postgresql.version>42.7.1</postgresql.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <spring-security.version>5.8.8</spring-security.version>
+        <spring-security.version>5.8.9</spring-security.version>
         <spring-hateoas.version>1.5.6</spring-hateoas.version>
         <okhttp.version>5.0.0-alpha.12</okhttp.version>
         <kotlin.version>1.9.21</kotlin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@ SPDX-License-Identifier: MIT
         -->
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <jackson-bom.version>2.16.1</jackson-bom.version>
-        <micrometer.version>1.12.0</micrometer.version>
+        <micrometer.version>1.12.2</micrometer.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- GeoTools up to 29.1 uses hsqldb 2.5.2, which has CVE-2022-41853, 29.2 and up provide 2.7.2,
           however spring-boot overrides that in org.springframework.boot:spring-boot-dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@ SPDX-License-Identifier: MIT
         -->
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <jackson-bom.version>2.16.1</jackson-bom.version>
+        <json-path.version>2.9.0</json-path.version>
         <micrometer.version>1.12.2</micrometer.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- GeoTools up to 29.1 uses hsqldb 2.5.2, which has CVE-2022-41853, 29.2 and up provide 2.7.2,

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@ SPDX-License-Identifier: MIT
         <hsqldb.version>2.7.2</hsqldb.version>
         <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <flyway.version>9.22.3</flyway.version>
-        <mssql-jdbc.version>12.4.1.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>12.4.2.jre11</mssql-jdbc.version>
         <oracle-database.version>23.3.0.23.09</oracle-database.version>
         <postgresql.version>42.7.1</postgresql.version>
         <snakeyaml.version>2.0</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ SPDX-License-Identifier: MIT
         to check
         -->
         <commons-lang3.version>3.14.0</commons-lang3.version>
-        <jackson-bom.version>2.16.0</jackson-bom.version>
+        <jackson-bom.version>2.16.1</jackson-bom.version>
         <micrometer.version>1.12.0</micrometer.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- GeoTools up to 29.1 uses hsqldb 2.5.2, which has CVE-2022-41853, 29.2 and up provide 2.7.2,

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@ SPDX-License-Identifier: MIT
         <pmd.version>6.55.0</pmd.version>
         <maven-fluido-skin.version>2.0.0-M8</maven-fluido-skin.version>
         <swagger-ui.version>5.10.3</swagger-ui.version>
-        <sentry.version>7.2.0</sentry.version>
+        <sentry.version>7.3.0</sentry.version>
         <errorProne.version>2.24.1</errorProne.version>
         <errorProneFlags>-XepDisableWarningsInGeneratedCode</errorProneFlags>
         <errorProneExcludePaths>${project.build.directory}/generated-sources/.*</errorProneExcludePaths>


### PR DESCRIPTION
- Bump jackson-bom.version from 2.16.0 to 2.16.1
- Bump mssql-jdbc.version from 12.4.1.jre11 to 12.4.2.jre11
- Bump micrometer.version from 1.12.0 to 1.12.2
- Bump spring-security.version from 5.8.8 to 5.8.9
- Add json-path.version override to resolve CVE-2023-51074 
- Bump mssql-jdbc.version from 12.4.2.jre11 to 12.6.0.jre11
- Update codecov/codecov-action from v3 to v4