### PR TITLE
Update pgjdbc to 42.7.2 to workaround CVE-2024-1597, also update mssql jdbc driver to latest patch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,9 +123,9 @@ SPDX-License-Identifier: MIT
         <hsqldb.version>2.7.2</hsqldb.version>
         <junit-jupiter.version>5.10.2</junit-jupiter.version>
         <flyway.version>9.22.3</flyway.version>
-        <mssql-jdbc.version>12.6.0.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>12.6.1.jre11</mssql-jdbc.version>
         <oracle-database.version>23.3.0.23.09</oracle-database.version>
-        <postgresql.version>42.7.1</postgresql.version>
+        <postgresql.version>42.7.2</postgresql.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-security.version>5.8.9</spring-security.version>
         <spring-hateoas.version>1.5.6</spring-hateoas.version>


### PR DESCRIPTION
Version 42.7.2 has a resolution for CVE-2024-1597