### PR TITLE
Bump GeoTools from 30.2 to 31.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@ SPDX-License-Identifier: MIT
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <project.build.outputTimestamp>2024-03-08T09:38:17Z</project.build.outputTimestamp>
-        <geotools.version>30.2</geotools.version>
+        <geotools.version>31-RC</geotools.version>
         <jts.version>1.19.0</jts.version>
         <spring.boot.version>${project.parent.version}</spring.boot.version>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@ SPDX-License-Identifier: MIT
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <project.build.outputTimestamp>2024-03-08T09:38:17Z</project.build.outputTimestamp>
-        <geotools.version>31-RC</geotools.version>
+        <geotools.version>31.0</geotools.version>
         <jts.version>1.19.0</jts.version>
         <spring.boot.version>${project.parent.version}</spring.boot.version>
         <!--


### PR DESCRIPTION
- [x] Bump GeoTools from 30.2 to [31-RC](https://github.com/geotools/geotools/releases/tag/31-RC)
- [x] Bump GeoTools from 31-RC to [31.0](https://github.com/geotools/geotools/releases/tag/31.0)