### PR TITLE
[HTM-1036] Java 17 compiler and runtime upgrade

### DIFF
--- a/.github/workflows/macos-maven.yml
+++ b/.github/workflows/macos-maven.yml
@@ -13,8 +13,8 @@ on:
 
 jobs:
   build:
-    name: Build w/ Java 11
-    runs-on: macos-12
+    name: Build w/ Java 17
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
 
       - name: 'Set up Maven'

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'maven'
 
       - name: 'Set up Maven'

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -27,7 +27,7 @@ jobs:
       - name: 'Set up JDK'
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: 'maven'
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'maven'
 
       - name: 'Set up Maven'

--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: 'maven'
 
@@ -78,7 +78,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: 'maven'
 
@@ -166,7 +166,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: 'maven'
 
@@ -224,7 +224,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         env:
           POSTGRES_USER: tailormap
           POSTGRES_PASSWORD: tailormap
@@ -238,9 +238,14 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: 'maven'
+
+      - name: 'Set up Maven'
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: '3.9.6'
 
       - name: Build docker image
         run: mvn -B -V -fae -DskipTests -DskipITs -DskipQA=true -Pqa-skip package

--- a/.github/workflows/windows-maven.yml
+++ b/.github/workflows/windows-maven.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
 
       - name: 'Set up Maven'

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,3 @@
--Djava.awt.headless=true -XX:+IgnoreUnrecognizedVMOptions -Djava.security.egd=file:/dev/./urandom
+-Djava.awt.headless=true
+-XX:+IgnoreUnrecognizedVMOptions
+-Djava.security.egd=file:/dev/./urandom

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 #
-FROM eclipse-temurin:11.0.22_7-jre
+FROM eclipse-temurin:17.0.10_7-jre
 
 ARG TAILORMAP_API_VERSION
 ARG BUILD_DATE

--- a/pom.xml
+++ b/pom.xml
@@ -92,14 +92,14 @@ SPDX-License-Identifier: MIT
         </site>
     </distributionManagement>
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <project.build.sourceVersion>${java.version}</project.build.sourceVersion>
-        <project.build.targetVersion>${java.version}</project.build.targetVersion>
-        <project.build.outputTimestamp>2024-02-28T09:57:27Z</project.build.outputTimestamp>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+        <project.build.outputTimestamp>2024-02-28T09:57:27Z</project.build.outputTimestamp>
         <geotools.version>30.2</geotools.version>
         <jts.version>1.19.0</jts.version>
         <spring.boot.version>${project.parent.version}</spring.boot.version>
@@ -764,6 +764,17 @@ SPDX-License-Identifier: MIT
                         <!--<arg>-Werror</arg>-->
                         <arg>-Xmaxwarns</arg>
                         <arg>1000</arg>
+                        <!-- see https://errorprone.info/docs/installation -->
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                     </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
@@ -1032,7 +1043,7 @@ SPDX-License-Identifier: MIT
                 <artifactId>modernizer-maven-plugin</artifactId>
                 <version>${modernizer-maven-plugin.version}</version>
                 <configuration>
-                    <javaVersion>11</javaVersion>
+                    <javaVersion>${java.version}</javaVersion>
                     <skip>${skipQA}</skip>
                     <failOnViolations>true</failOnViolations>
                 </configuration>
@@ -1099,7 +1110,7 @@ SPDX-License-Identifier: MIT
                             <rules>
                                 <!-- see https://maven.apache.org/enforcer/enforcer-rules/index.html -->
                                 <requireMavenVersion>
-                                    <version>3.8</version>
+                                    <version>3.9</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>${java.version}</version>


### PR DESCRIPTION
Upgrade to Java 17, this is the first step towards upgrading to Spring Boot 3.x which requires Java 17 as a baseline.

resolves HTM-1036