### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ SPDX-License-Identifier: MIT
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <jackson-bom.version>2.16.2</jackson-bom.version>
         <json-path.version>2.9.0</json-path.version>
-        <micrometer.version>1.12.2</micrometer.version>
+        <micrometer.version>1.12.4</micrometer.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- GeoTools up to 29.1 uses hsqldb 2.5.2, which has CVE-2022-41853, 29.2 and up provide 2.7.2,
           however spring-boot overrides that in org.springframework.boot:spring-boot-dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@ SPDX-License-Identifier: MIT
         <logback.version>1.4.1</logback.version>
         <slf4j.version>2.0.2</slf4j.version>
         -->
-        <webjars-locator-core.version>0.55</webjars-locator-core.version>
+        <webjars-locator-core.version>0.58</webjars-locator-core.version>
         <maven.surefire.version>3.0.0</maven.surefire.version>
         <maven-surefire-plugin.version>${maven.surefire.version}</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>${maven.surefire.version}</maven-failsafe-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1110,10 +1110,12 @@ SPDX-License-Identifier: MIT
                             <rules>
                                 <!-- see https://maven.apache.org/enforcer/enforcer-rules/index.html -->
                                 <requireMavenVersion>
-                                    <version>3.9</version>
+                                    <version>3.9.5</version>
+                                    <message>Requires Maven 3.9.5 or higher</message>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>${java.version}</version>
+                                    <message>Requires Java ${java.version} or higher</message>
                                 </requireJavaVersion>
                                 <bannedDependencies>
                                     <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ SPDX-License-Identifier: MIT
         to check
         -->
         <commons-lang3.version>3.14.0</commons-lang3.version>
-        <jackson-bom.version>2.16.1</jackson-bom.version>
+        <jackson-bom.version>2.16.2</jackson-bom.version>
         <json-path.version>2.9.0</json-path.version>
         <micrometer.version>1.12.2</micrometer.version>
         <hibernate.version>5.6.15.Final</hibernate.version>


### PR DESCRIPTION
While checking dependencies for SPring 6 upgrade:

- [x] Bump `jackson-bom.version` from 2.16.1 to 2.16.2
- [x] Bump `micrometer.version` from 1.12.2 to 1.12.4
- [x] Bump `webjars-locator-core.version` from 0.55 to 0.58
- [x] We need at least Maven 3.9.5 for `org.gaul:modernizer-maven-plugin:2.8.0`