### PR TITLE
Bump dependency-check-maven.version from 9.0.9 to 9.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ SPDX-License-Identifier: MIT
         <maven-pmd-plugin.version>3.21.2</maven-pmd-plugin.version>
         <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
-        <dependency-check-maven.version>9.0.9</dependency-check-maven.version>
+        <dependency-check-maven.version>9.0.10</dependency-check-maven.version>
         <modernizer-maven-plugin.version>2.8.0</modernizer-maven-plugin.version>
         <pmd.version>6.55.0</pmd.version>
         <maven-fluido-skin.version>2.0.0-M8</maven-fluido-skin.version>


### PR DESCRIPTION
see https://github.com/jeremylong/DependencyCheck/blob/main/CHANGELOG.md#version-9010-2024-03-15