### PR TITLE
[HTM-1058] Solr indexing and API

### DIFF
--- a/build/ci/docker-compose.yml
+++ b/build/ci/docker-compose.yml
@@ -1,7 +1,6 @@
 # Copyright (C) 2022 B3Partners B.V.
 #
 # SPDX-License-Identifier: MIT
-version: '3.9'
 name: 'tailormap-ci'
 
 volumes:
@@ -80,8 +79,7 @@ services:
   oracle:
     container_name: oracle
     image: docker.b3p.nl/b3partners/tailormap-data_oracle:snapshot
-    environment:
-      # Note Oracle has default maximum password length of 16!
+    environment: # Note Oracle has default maximum password length of 16!
       ORACLE_PASSWORD: ${ORACLE_PASSWORD:-fa6efb5b-075b-4b}
       # this user is created in XEPDB1, not in XE
       APP_USER: "geodata"
@@ -128,6 +126,9 @@ services:
     container_name: solr-status
     depends_on:
       - solr
+    profiles:
+      # in the CI scenario, we don't want to run the solr-exporter
+      - monitoring-enabled
     image: solr:latest
     ports:
       - "127.0.0.1:9854:9854"
@@ -138,5 +139,8 @@ services:
       PORT: 9854
       SCRAPE_INTERVAL: 15
       SOLR_URL: http://solr:8983/solr/
+    restart: unless-stopped
     command:
-      - /opt/solr-9.5.0/prometheus-exporter/bin/solr-exporter
+      # this script should be in the path for the current user
+      # /opt/solr-9.5.0/prometheus-exporter/bin/solr-exporter
+      - solr-exporter

--- a/build/ci/docker-compose.yml
+++ b/build/ci/docker-compose.yml
@@ -111,7 +111,8 @@ services:
       - sqlserver
     image: solr:latest
     environment:
-      SOLR_HEAP: 512m
+      TZ: Europe/Amsterdam
+      SOLR_HEAP: 1g
     volumes:
       - solr-data:/var/solr
     ports:
@@ -122,3 +123,20 @@ services:
     command:
       - solr-precreate
       - tailormap
+
+  solr-status:
+    container_name: solr-status
+    depends_on:
+      - solr
+    image: solr:latest
+    ports:
+      - "127.0.0.1:9854:9854"
+    networks:
+      - tailormap-data
+    environment:
+      TZ: Europe/Amsterdam
+      PORT: 9854
+      SCRAPE_INTERVAL: 15
+      SOLR_URL: http://solr:8983/solr/
+    command:
+      - /opt/solr-9.5.0/prometheus-exporter/bin/solr-exporter

--- a/build/ci/docker-compose.yml
+++ b/build/ci/docker-compose.yml
@@ -2,11 +2,13 @@
 #
 # SPDX-License-Identifier: MIT
 version: '3.9'
+name: 'tailormap-ci'
 
 volumes:
   postgis-db:
   sqlserver-db:
   oracle-db:
+  solr-data:
 
 
 networks:
@@ -100,3 +102,23 @@ services:
       start_period: 1m
       test: healthcheck.sh
     restart: unless-stopped
+
+  solr:
+    container_name: solr
+    depends_on:
+      - postgis
+      - oracle
+      - sqlserver
+    image: solr:latest
+    environment:
+      SOLR_HEAP: 512m
+    volumes:
+      - solr-data:/var/solr
+    ports:
+      - "127.0.0.1:8983:8983"
+    networks:
+      - tailormap-data
+    restart: unless-stopped
+    command:
+      - solr-precreate
+      - tailormap

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@ SPDX-License-Identifier: MIT
         <geotools.version>31.0</geotools.version>
         <jts.version>1.19.0</jts.version>
         <spring.boot.version>${project.parent.version}</spring.boot.version>
+
+        <!-- solr and jetty versions may need to match
+        <jetty.version>10.0.19</jetty.version>
+        -->
+        <solr.version>9.5.0</solr.version>
+
         <!--
         Spring Boot version overrides.
         See org.springframework.boot:spring-boot-dependencies
@@ -211,6 +217,11 @@ SPDX-License-Identifier: MIT
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-micrometer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-solrj</artifactId>
+            <version>${solr.version}</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,12 +103,10 @@ SPDX-License-Identifier: MIT
         <geotools.version>31.0</geotools.version>
         <jts.version>1.19.0</jts.version>
         <spring.boot.version>${project.parent.version}</spring.boot.version>
-
-        <!-- solr and jetty versions may need to match
-        <jetty.version>10.0.19</jetty.version>
-        -->
+        <!-- solr and jetty versions may need to match to prevent errors such as
+        Caused by: java.lang.NoClassDefFoundError: org/eclipse/jetty/client/util/InputStreamResponseListener -->
+        <jetty.version>10.0.20</jetty.version>
         <solr.version>9.5.0</solr.version>
-
         <!--
         Spring Boot version overrides.
         See org.springframework.boot:spring-boot-dependencies
@@ -190,6 +188,15 @@ SPDX-License-Identifier: MIT
                 <groupId>org.gaul</groupId>
                 <artifactId>modernizer-maven-annotations</artifactId>
                 <version>${modernizer-maven-plugin.version}</version>
+            </dependency>
+            <dependency>
+                <!-- override the jetty-ee10-bom import so we can downgrade jetty to a solrj compatible version,
+                 our spring-boot parent provides this import -->
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-bom</artifactId>
+                <version>12.0.7</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -1192,6 +1199,7 @@ SPDX-License-Identifier: MIT
                                         <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
                                         <exclude>org.flywaydb:flyway-core</exclude>
                                         <exclude>ch.rasc:sse-eventbus</exclude>
+                                        <exclude>org.apache.solr:solr-solrj</exclude>
                                     </excludes>
                                 </banTransitiveDependencies>
                             </rules>

--- a/src/main/java/nl/b3p/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/nl/b3p/tailormap/api/configuration/dev/PopulateTestData.java
@@ -725,6 +725,9 @@ public class PopulateTestData {
               ft.getSettings().addAttributeOrderItem("identificatie");
               ft.getSettings().addAttributeOrderItem("bronhouder");
               ft.getSettings().addAttributeOrderItem("class");
+              ft.getSettings()
+                  .setSearchFields(List.of("class", "plus_fysiekvoorkomen", "bronhouder"));
+              ft.getSettings().setSearchDisplayFields(List.of("class", "plus_fysiekvoorkomen"));
             });
 
     List<AppTreeNode> baseNodes =

--- a/src/main/java/nl/b3p/tailormap/api/controller/SearchController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/SearchController.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.controller;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeUnit;
+import nl.b3p.tailormap.api.annotation.AppRestController;
+import nl.b3p.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
+import nl.b3p.tailormap.api.persistence.Application;
+import nl.b3p.tailormap.api.persistence.GeoService;
+import nl.b3p.tailormap.api.persistence.TMFeatureType;
+import nl.b3p.tailormap.api.persistence.json.AppTreeLayerNode;
+import nl.b3p.tailormap.api.persistence.json.GeoServiceLayer;
+import nl.b3p.tailormap.api.repository.FeatureSourceRepository;
+import nl.b3p.tailormap.api.solr.SolrHelper;
+import nl.b3p.tailormap.api.viewer.model.SearchResponse;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
+import org.apache.solr.common.SolrException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.server.ResponseStatusException;
+
+@AppRestController
+@Validated
+@RequestMapping(
+    path = "${tailormap-api.base-path}/{viewerKind}/{viewerName}/layer/{appLayerId}/search",
+    produces = MediaType.APPLICATION_JSON_VALUE)
+public class SearchController {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final FeatureSourceFactoryHelper featureSourceFactoryHelper;
+
+  private final FeatureSourceRepository featureSourceRepository;
+
+  @Value("${tailormap-api.solr-url}")
+  private String solrUrl;
+
+  @Value("${tailormap-api.solr-core-name:tailormap}")
+  private String solrCoreName;
+
+  @Value("${tailormap-api.pageSize:100}")
+  private int numResultsToReturn;
+
+  public SearchController(
+      FeatureSourceFactoryHelper featureSourceFactoryHelper,
+      FeatureSourceRepository featureSourceRepository) {
+    this.featureSourceFactoryHelper = featureSourceFactoryHelper;
+    this.featureSourceRepository = featureSourceRepository;
+  }
+
+  @Transactional(readOnly = true)
+  @RequestMapping(method = {GET})
+  @Timed(value = "search", description = "time spent to process search a request")
+  @Counted(value = "search", description = "number of search calls")
+  public ResponseEntity<Serializable> search(
+      @ModelAttribute AppTreeLayerNode appTreeLayerNode,
+      @ModelAttribute GeoService service,
+      @ModelAttribute GeoServiceLayer layer,
+      @ModelAttribute Application application,
+      @RequestParam(required = false) final String q,
+      @RequestParam(required = false, defaultValue = "0") Integer start) {
+
+    if (layer == null) {
+      throw new ResponseStatusException(
+          HttpStatus.NOT_FOUND, "Can't find layer " + appTreeLayerNode);
+    }
+    TMFeatureType tmFeatureType = service.findFeatureTypeForLayer(layer, featureSourceRepository);
+    if (tmFeatureType == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Layer does not have feature type");
+    }
+
+    try (SolrClient solrClient = getSolrClient();
+        SolrHelper solrHelper = new SolrHelper(solrClient, featureSourceFactoryHelper)) {
+      final SearchResponse searchResponse =
+          solrHelper.findInIndex(
+              SolrHelper.getIndexLayerId(service.getId(), layer.getName()),
+              q,
+              start,
+              numResultsToReturn);
+
+      return (null == searchResponse.getDocuments() || searchResponse.getDocuments().isEmpty())
+          ? ResponseEntity.noContent().build()
+          : ResponseEntity.ok().body(searchResponse);
+    } catch (SolrServerException | IOException e) {
+      logger.error("Error while contacting Solr", e);
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR, "Error while searching", e);
+    } catch (SolrException e) {
+      logger.error("Error while searching", e);
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Error while searching with given query", e);
+    }
+  }
+
+  private SolrClient getSolrClient() {
+    return new Http2SolrClient.Builder(solrUrl + solrCoreName)
+        .withConnectionTimeout(10, TimeUnit.SECONDS)
+        .withFollowRedirects(true)
+        .build();
+  }
+}

--- a/src/main/java/nl/b3p/tailormap/api/controller/admin/SolrAdminController.java
+++ b/src/main/java/nl/b3p/tailormap/api/controller/admin/SolrAdminController.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.controller.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.annotation.Timed;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeUnit;
+import nl.b3p.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
+import nl.b3p.tailormap.api.persistence.GeoService;
+import nl.b3p.tailormap.api.persistence.TMFeatureType;
+import nl.b3p.tailormap.api.repository.FeatureSourceRepository;
+import nl.b3p.tailormap.api.repository.GeoServiceRepository;
+import nl.b3p.tailormap.api.solr.SolrUtil;
+import nl.b3p.tailormap.api.viewer.model.ErrorResponse;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.ConcurrentUpdateHttp2SolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
+import org.apache.solr.client.solrj.response.SolrPingResponse;
+import org.apache.solr.common.SolrException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+public class SolrAdminController {
+  @Value("${tailormap-api.solr-url}")
+  private String solrUrl;
+
+  @Value("${tailormap-api.solr-core-name:tailormap}")
+  private String solrCoreName;
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final FeatureSourceFactoryHelper featureSourceFactoryHelper;
+
+  private final FeatureSourceRepository featureSourceRepository;
+
+  private final GeoServiceRepository geoServiceRepository;
+
+  public SolrAdminController(
+      FeatureSourceFactoryHelper featureSourceFactoryHelper,
+      FeatureSourceRepository featureSourceRepository,
+      GeoServiceRepository geoServiceRepository) {
+    this.featureSourceFactoryHelper = featureSourceFactoryHelper;
+    this.featureSourceRepository = featureSourceRepository;
+    this.geoServiceRepository = geoServiceRepository;
+  }
+
+  /**
+   * Ping solr.
+   *
+   * @return the response entity (ok or an error response)
+   */
+  @GetMapping(path = "${tailormap-api.admin.base-path}/index/ping")
+  public ResponseEntity<?> pingSolr() {
+    try (SolrClient solrClient = getSolrClient()) {
+      final SolrPingResponse ping = solrClient.ping();
+      logger.info("Solr ping status {}", ping.getResponse().get("status"));
+      return ResponseEntity.ok(
+          new ObjectMapper()
+              .createObjectNode()
+              .put("status", ping.getResponse().get("status").toString())
+              .put("timeElapsed", ping.getElapsedTime()));
+    } catch (IOException | SolrServerException e) {
+      logger.error("Error pinging solr", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+              new ErrorResponse()
+                  .message(e.getLocalizedMessage())
+                  .code(HttpStatus.INTERNAL_SERVER_ERROR.value()));
+    }
+  }
+
+  private SolrClient getSolrClient() {
+    return new ConcurrentUpdateHttp2SolrClient.Builder(
+            solrUrl + solrCoreName,
+            new Http2SolrClient.Builder()
+                .withFollowRedirects(true)
+                .withConnectionTimeout(10000, TimeUnit.MILLISECONDS)
+                .withRequestTimeout(60000, TimeUnit.MILLISECONDS)
+                .build())
+        .withQueueSize(SolrUtil.SOLR_BATCH_SIZE * 2)
+        .withThreadCount(10)
+        .build();
+  }
+
+  /**
+   * (re-) Index a layer.
+   *
+   * @param geoserviceId the geoservice id
+   * @param layerId the layer id
+   * @return the response entity (accepted or an error response)
+   */
+  @Transactional
+  @Timed(value = "index_feature_type", description = "time spent to index feature type")
+  @PutMapping(path = "${tailormap-api.admin.base-path}/index/{geoserviceId}/{layerId}")
+  public ResponseEntity<?> index(@PathVariable String geoserviceId, @PathVariable String layerId) {
+    GeoService geoService =
+        geoServiceRepository
+            .findById(geoserviceId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    TMFeatureType tmFeatureType =
+        geoService.findFeatureTypeForLayer(geoService.findLayer(layerId), featureSourceRepository);
+    if (tmFeatureType == null) {
+
+      return ResponseEntity.status(HttpStatus.NOT_FOUND)
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+              new ErrorResponse()
+                  .message("Layer does not have feature type")
+                  .code(HttpStatus.NOT_FOUND.value()));
+    }
+
+    try (SolrClient solrClient = getSolrClient();
+        SolrUtil solrUtil = new SolrUtil(solrClient, featureSourceFactoryHelper)) {
+      solrUtil.addFeatureTypeIndexForLayer(
+          SolrUtil.getIndexLayerId(geoserviceId, layerId), tmFeatureType);
+    } catch (UnsupportedOperationException | IOException | SolrServerException | SolrException e) {
+      logger.error("Error indexing", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+              new ErrorResponse()
+                  .message(e.getLocalizedMessage())
+                  .code(HttpStatus.INTERNAL_SERVER_ERROR.value()));
+    }
+
+    logger.info("Indexing finished");
+    // TODO if created return 201 if updated return 204
+    return ResponseEntity.accepted().build();
+  }
+
+  /**
+   * Clear index for the given service and layer. Since deleting a non-existing index is a no-op,
+   * this will not cause an error and return .
+   *
+   * @param geoserviceId the geoservice id
+   * @param layerName the layer id
+   * @return the response entity ({@code 204 NOCONTENT} or an error response)
+   */
+  @Timed(value = "index_delete", description = "time spent to delete an index of a feature type")
+  @DeleteMapping(path = "${tailormap-api.admin.base-path}/index/{geoserviceId}/{layerName}")
+  public ResponseEntity<?> clearIndex(
+      @PathVariable String geoserviceId, @PathVariable String layerName) {
+    try (SolrClient solrClient = getSolrClient();
+        SolrUtil solrUtil = new SolrUtil(solrClient, featureSourceFactoryHelper)) {
+      solrUtil.clearIndexForLayer(SolrUtil.getIndexLayerId(geoserviceId, layerName));
+    } catch (IOException | SolrServerException e) {
+      logger.error("Error clearing index", e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+              new ErrorResponse()
+                  .message(e.getLocalizedMessage())
+                  .code(HttpStatus.INTERNAL_SERVER_ERROR.value()));
+    }
+
+    logger.info("Index cleared");
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/nl/b3p/tailormap/api/geotools/processing/GeometryProcessor.java
+++ b/src/main/java/nl/b3p/tailormap/api/geotools/processing/GeometryProcessor.java
@@ -104,7 +104,7 @@ public final class GeometryProcessor {
   private static String simplify(@NotNull Geometry geom) {
     final int megabytes = 2097152 /* 2MB is the default tomcat max post size */ - 100 * 1024;
 
-    logger.debug("PrecisionModel scale: {}", geom.getPrecisionModel().getScale());
+    logger.trace("PrecisionModel scale: {}", geom.getPrecisionModel().getScale());
     PrecisionModel pm = new PrecisionModel(geom.getPrecisionModel());
     GeometryPrecisionReducer gpr = new GeometryPrecisionReducer(pm);
     geom = gpr.reduce(geom);

--- a/src/main/java/nl/b3p/tailormap/api/persistence/GeoService.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/GeoService.java
@@ -38,6 +38,7 @@ import nl.b3p.tailormap.api.persistence.json.ServiceAuthentication;
 import nl.b3p.tailormap.api.persistence.json.TMServiceCaps;
 import nl.b3p.tailormap.api.persistence.listener.EntityEventPublisher;
 import nl.b3p.tailormap.api.repository.FeatureSourceRepository;
+import nl.b3p.tailormap.api.repository.SearchIndexRepository;
 import nl.b3p.tailormap.api.util.TMStringUtils;
 import nl.b3p.tailormap.api.viewer.model.Service;
 import org.apache.commons.lang3.StringUtils;
@@ -436,6 +437,34 @@ public class GeoService {
       }
     }
     return tmft;
+  }
+
+  /**
+   * Find the search index for the given layer. If the layer has a specific search index, that one
+   * is returned. If not, {@code null} is returned.
+   *
+   * @param layer the layer to find the search index for
+   * @param searchIndexRepository repository to find the search index
+   * @return the search index for the layer, or {@code null} if no search index is found
+   */
+  public Optional<SearchIndex> findSearchIndexForLayer(
+      GeoServiceLayer layer, SearchIndexRepository searchIndexRepository) {
+
+    GeoServiceDefaultLayerSettings defaultLayerSettings = getSettings().getDefaultLayerSettings();
+    GeoServiceLayerSettings layerSettings = getLayerSettings(layer.getName());
+
+    Long searchIndexId = null;
+    if (layerSettings != null && layerSettings.getSearchIndex() != null) {
+      searchIndexId = layerSettings.getSearchIndex().getSearchIndexId();
+    }
+    if (searchIndexId == null
+        && defaultLayerSettings != null
+        && defaultLayerSettings.getSearchIndex() != null) {
+      searchIndexId = defaultLayerSettings.getSearchIndex().getSearchIndexId();
+    }
+    return (null == searchIndexId)
+        ? Optional.empty()
+        : searchIndexRepository.findById(searchIndexId);
   }
 
   /**

--- a/src/main/java/nl/b3p/tailormap/api/persistence/SearchIndex.java
+++ b/src/main/java/nl/b3p/tailormap/api/persistence/SearchIndex.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.persistence;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.hibernate.annotations.Type;
+import org.springframework.format.annotation.DateTimeFormat;
+
+/** SearchIndex is a table that stores the metadata for search indexes for a feature type. */
+@Entity
+@Table(name = "search_index")
+public class SearchIndex implements Serializable {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long featureTypeId;
+
+  /** List of attribute names that were used last last when building the search index. */
+  @JsonProperty("searchFieldsUsed")
+  @Type(value = io.hypersistence.utils.hibernate.type.json.JsonBinaryType.class)
+  @Column(columnDefinition = "jsonb")
+  @Valid
+  private List<String> searchFieldsUsed;
+
+  /** List of attribute names for display that were used last when building the search index. */
+  @JsonProperty("searchDisplayFieldsUsed")
+  @Type(value = io.hypersistence.utils.hibernate.type.json.JsonBinaryType.class)
+  @Column(columnDefinition = "jsonb")
+  @Valid
+  private List<String> searchDisplayFieldsUsed;
+
+  @Column(columnDefinition = "text")
+  private String comment;
+
+  /** Date and time of last index creation. */
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+  @Valid
+  @JsonProperty("lastIndexed")
+  private OffsetDateTime lastIndexed;
+
+  public enum Status {
+    INITIAL("initial"),
+    INDEXING("indexing"),
+    INDEXED("indexed"),
+    ERROR("error");
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    public static SearchIndex.Status fromValue(String value) {
+      for (SearchIndex.Status status : SearchIndex.Status.values()) {
+        if (status.value.equals(value)) {
+          return status;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '%s'".formatted(value));
+    }
+  }
+
+  @Enumerated(EnumType.STRING)
+  @NotNull
+  @Column(columnDefinition = "varchar(8) default 'INITIAL'")
+  private SearchIndex.Status status = SearchIndex.Status.INITIAL;
+
+  public SearchIndex id(Long id) {
+    this.id = id;
+    return this;
+  }
+
+  public Long getId() {
+    return this.id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public SearchIndex featureTypeId(Long featureTypeName) {
+    this.featureTypeId = featureTypeName;
+    return this;
+  }
+
+  public Long getFeatureTypeId() {
+    return this.featureTypeId;
+  }
+
+  public void setFeatureTypeId(Long featureTypeName) {
+    this.featureTypeId = featureTypeName;
+  }
+
+  public String getComment() {
+    return this.comment;
+  }
+
+  public void setComment(String comment) {
+    this.comment = comment;
+  }
+
+  public SearchIndex searchFieldsUsed(List<String> searchFields) {
+    this.searchFieldsUsed = searchFields;
+    return this;
+  }
+
+  public SearchIndex addSearchFieldsUsedItem(String searchFieldsItem) {
+    if (this.searchFieldsUsed == null) {
+      this.searchFieldsUsed = new ArrayList<>();
+    }
+    this.searchFieldsUsed.add(searchFieldsItem);
+    return this;
+  }
+
+  public List<String> getSearchFieldsUsed() {
+    return this.searchFieldsUsed;
+  }
+
+  public void setSearchFieldsUsed(List<String> searchFields) {
+    this.searchFieldsUsed = searchFields;
+  }
+
+  public SearchIndex searchDisplayFieldsUsed(List<String> searchDisplayFields) {
+    this.searchDisplayFieldsUsed = searchDisplayFields;
+    return this;
+  }
+
+  public SearchIndex addSearchDisplayFieldsUsedItem(String searchDisplayFieldsItem) {
+    if (this.searchDisplayFieldsUsed == null) {
+      this.searchDisplayFieldsUsed = new ArrayList<>();
+    }
+    this.searchDisplayFieldsUsed.add(searchDisplayFieldsItem);
+    return this;
+  }
+
+  public List<String> getSearchDisplayFieldsUsed() {
+    return searchDisplayFieldsUsed;
+  }
+
+  public void setSearchDisplayFieldsUsed(List<String> searchDisplayFields) {
+    this.searchDisplayFieldsUsed = searchDisplayFields;
+  }
+
+  public SearchIndex status(SearchIndex.Status status) {
+    this.status = status;
+    return this;
+  }
+
+  public SearchIndex.Status getStatus() {
+    return this.status;
+  }
+
+  public void setStatus(SearchIndex.Status status) {
+    this.status = status;
+  }
+
+  public SearchIndex lastIndexed(OffsetDateTime lastIndexed) {
+    this.lastIndexed = lastIndexed;
+    return this;
+  }
+
+  public OffsetDateTime getLastIndexed() {
+    return this.lastIndexed;
+  }
+
+  public void setLastIndexed(OffsetDateTime lastIndexed) {
+    this.lastIndexed = lastIndexed;
+  }
+}

--- a/src/main/java/nl/b3p/tailormap/api/repository/SearchIndexRepository.java
+++ b/src/main/java/nl/b3p/tailormap/api/repository/SearchIndexRepository.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.repository;
+
+import java.util.List;
+import nl.b3p.tailormap.api.persistence.SearchIndex;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(
+    path = "search-indexes",
+    collectionResourceRel = "search-indexes",
+    itemResourceRel = "search-index")
+public interface SearchIndexRepository extends JpaRepository<SearchIndex, Long> {
+  List<SearchIndex> findByFeatureTypeId(Long featureTypeId);
+}

--- a/src/main/java/nl/b3p/tailormap/api/solr/FeatureDocument.java
+++ b/src/main/java/nl/b3p/tailormap/api/solr/FeatureDocument.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.solr;
+
+import nl.b3p.tailormap.api.util.Constants;
+import org.apache.solr.client.solrj.beans.Field;
+
+public class FeatureDocument implements Constants {
+  @Field(value = "id")
+  private final String __fid;
+
+  @Field(value = SEARCH_LAYER)
+  private final String searchLayer;
+
+  @Field(value = INDEX_SEARCH_FIELD)
+  private String[] searchFields;
+
+  @Field(value = INDEX_DISPLAY_FIELD)
+  private String[] displayFields;
+
+  @Field(value = INDEX_GEOM_FIELD)
+  private String geometry;
+
+  public FeatureDocument(String __fid, String searchLayerId) {
+    this.__fid = __fid;
+    this.searchLayer = searchLayerId;
+  }
+
+  public void setGeometry(String wktGeometry) {
+    this.geometry = wktGeometry;
+  }
+
+  public void setSearchFields(String[] searchFields) {
+    this.searchFields = searchFields;
+  }
+
+  public void setDisplayFields(String[] displayFields) {
+    this.displayFields = displayFields;
+  }
+}

--- a/src/main/java/nl/b3p/tailormap/api/solr/FeatureIndexingDocument.java
+++ b/src/main/java/nl/b3p/tailormap/api/solr/FeatureIndexingDocument.java
@@ -15,7 +15,7 @@ public class FeatureIndexingDocument implements Constants {
 
   @Field(value = SEARCH_LAYER)
   @SuppressWarnings("unused")
-  private final String searchLayer;
+  private final Long searchLayer;
 
   @Field(value = INDEX_SEARCH_FIELD)
   @SuppressWarnings("unused")
@@ -29,7 +29,7 @@ public class FeatureIndexingDocument implements Constants {
   @SuppressWarnings("unused")
   private String geometry;
 
-  public FeatureIndexingDocument(String fid, String searchLayerId) {
+  public FeatureIndexingDocument(String fid, Long searchLayerId) {
     this.fid = fid;
     this.searchLayer = searchLayerId;
   }

--- a/src/main/java/nl/b3p/tailormap/api/solr/FeatureIndexingDocument.java
+++ b/src/main/java/nl/b3p/tailormap/api/solr/FeatureIndexingDocument.java
@@ -8,24 +8,29 @@ package nl.b3p.tailormap.api.solr;
 import nl.b3p.tailormap.api.util.Constants;
 import org.apache.solr.client.solrj.beans.Field;
 
-public class FeatureDocument implements Constants {
-  @Field(value = "id")
-  private final String __fid;
+public class FeatureIndexingDocument implements Constants {
+  @Field(value = ID)
+  @SuppressWarnings("unused")
+  private final String fid;
 
   @Field(value = SEARCH_LAYER)
+  @SuppressWarnings("unused")
   private final String searchLayer;
 
   @Field(value = INDEX_SEARCH_FIELD)
+  @SuppressWarnings("unused")
   private String[] searchFields;
 
   @Field(value = INDEX_DISPLAY_FIELD)
+  @SuppressWarnings("unused")
   private String[] displayFields;
 
   @Field(value = INDEX_GEOM_FIELD)
+  @SuppressWarnings("unused")
   private String geometry;
 
-  public FeatureDocument(String __fid, String searchLayerId) {
-    this.__fid = __fid;
+  public FeatureIndexingDocument(String fid, String searchLayerId) {
+    this.fid = fid;
     this.searchLayer = searchLayerId;
   }
 

--- a/src/main/java/nl/b3p/tailormap/api/solr/SolrHelper.java
+++ b/src/main/java/nl/b3p/tailormap/api/solr/SolrHelper.java
@@ -261,6 +261,10 @@ public class SolrHelper implements AutoCloseable, Constants {
     if (null == solrQuery || solrQuery.isBlank()) {
       solrQuery = "*";
     }
+    // TODO We could escape special/syntax characters, but that also prevents using keys like ~ and
+    // *
+    // solrQuery = ClientUtils.escapeQueryChars(solrQuery);
+
     final SolrQuery query =
         new SolrQuery(INDEX_SEARCH_FIELD + ":" + solrQuery)
             .setShowDebugInfo(logger.isDebugEnabled())

--- a/src/main/java/nl/b3p/tailormap/api/solr/SolrUtil.java
+++ b/src/main/java/nl/b3p/tailormap/api/solr/SolrUtil.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.solr;
+
+import jakarta.validation.constraints.NotNull;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import nl.b3p.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
+import nl.b3p.tailormap.api.persistence.TMFeatureType;
+import nl.b3p.tailormap.api.util.Constants;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.schema.SchemaRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.client.solrj.response.schema.SchemaResponse;
+import org.apache.solr.common.SolrDocumentList;
+import org.geotools.api.data.Query;
+import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.locationtech.jts.geom.Geometry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Solr utility class. This class provides methods to add or update a full-text feature type index
+ * for a layer, find in the index for a layer, and clear the index for a layer. It also provides a
+ * method to close the Solr client as well as automatically closing the client when used in a
+ * try-with-resources.
+ */
+public class SolrUtil implements AutoCloseable, Constants {
+  private final SolrClient solrClient;
+  private final FeatureSourceFactoryHelper featureSourceFactoryHelper;
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  public static final int SOLR_BATCH_SIZE = 1000;
+
+  /**
+   * Constructor.
+   *
+   * @param solrClient the Solr client
+   * @param featureSourceFactoryHelper the feature source factory helper
+   */
+  public SolrUtil(
+      @NotNull SolrClient solrClient,
+      @NotNull FeatureSourceFactoryHelper featureSourceFactoryHelper) {
+    this.solrClient = solrClient;
+    this.featureSourceFactoryHelper = featureSourceFactoryHelper;
+  }
+
+  public static String getIndexLayerId(String serviceId, String layerName) {
+    return (serviceId + "__" + layerName).replaceAll(":", "__");
+  }
+
+  /**
+   * Add or update a feature type index for a layer.
+   *
+   * @param indexLayerId the layer name, as created by using {@link #getIndexLayerId(String,
+   *     String)}
+   * @param tmFeatureType the feature type
+   * @throws UnsupportedOperationException if the operation is not supported, possibly because not
+   *     search field shave been defined
+   * @throws IOException if an I/O error occurs
+   * @throws SolrServerException if a Solr error occurs
+   */
+  public void addFeatureTypeIndexForLayer(String indexLayerId, TMFeatureType tmFeatureType)
+      throws UnsupportedOperationException, IOException, SolrServerException {
+
+    createSchemaIfNotExists();
+
+    List<String> searchFields = tmFeatureType.getSettings().getSearchFields();
+    List<String> displayFields = tmFeatureType.getSettings().getSearchDisplayFields();
+    if (null == searchFields || searchFields.isEmpty()) {
+      logger.info("No search fields configured for layer id: {}", indexLayerId);
+      throw new UnsupportedOperationException(
+          "No search fields configured for layer id: " + indexLayerId);
+    }
+
+    // add search and display properties to query
+    Set<String> propertyNames = new HashSet<>();
+    // always add primary key and default geometry to geotools query
+    propertyNames.add(tmFeatureType.getPrimaryKeyAttribute());
+    propertyNames.add(tmFeatureType.getDefaultGeometryAttribute());
+    propertyNames.addAll(searchFields);
+
+    final boolean hasDisplayFields = displayFields != null && !displayFields.isEmpty();
+    if (hasDisplayFields) {
+      propertyNames.addAll(displayFields);
+    }
+
+    clearIndexForLayer(indexLayerId);
+    logger.info("Indexing started for layer id: {}", indexLayerId);
+    // collect features to index
+    SimpleFeatureSource fs = featureSourceFactoryHelper.openGeoToolsFeatureSource(tmFeatureType);
+    Query q = new Query(fs.getName().toString());
+    //    if (propertyNames.size() < 3) {
+    //      // no search or display fields configured,
+    //      // add all non-hidden string type properties to the query
+    //      tmFeatureType
+    //          .getAttributes()
+    //          .forEach(
+    //              a -> {
+    //                if (TMAttributeTypeHelper.isGeometry(a.getType())
+    //                    || a.getType() != TMAttributeType.STRING
+    //                    || tmFeatureType.getSettings().getHideAttributes().contains(a.getName()))
+    // {
+    //                  return;
+    //                }
+    //                propertyNames.add(a.getName());
+    //              });
+    //    }
+    // filter out any hidden properties (there should be none
+    tmFeatureType.getSettings().getHideAttributes().forEach(propertyNames::remove);
+    q.setPropertyNames(List.copyOf(propertyNames));
+    q.setStartIndex(0);
+    // TODO: make maxFeatures configurable? perhaps for WFS sources?
+    // q.setMaxFeatures(10);
+    logger.trace("Indexing query: {}", q);
+    SimpleFeatureCollection simpleFeatureCollection = fs.getFeatures(q);
+    List<FeatureDocument> docsBatch = new ArrayList<>(SOLR_BATCH_SIZE);
+    // TODO this does not currently batch the feature source query
+    UpdateResponse updateResponse;
+    try (SimpleFeatureIterator iterator = simpleFeatureCollection.features()) {
+      int indexCounter = 0;
+      while (iterator.hasNext()) {
+        indexCounter++;
+        SimpleFeature feature = iterator.next();
+        // note that this will create a unique document
+        FeatureDocument doc = new FeatureDocument(feature.getID(), indexLayerId);
+        // TODO these fields are added as a multivalued field, but should be single valued
+        List<String> searchValues = new ArrayList<>();
+        List<String> displayValues = new ArrayList<>();
+        propertyNames.forEach(
+            propertyName -> {
+              Object value = feature.getAttribute(propertyName);
+              if (value != null) {
+                if (value instanceof Geometry) {
+                  doc.setGeometry(((Geometry) value).toText());
+                } else {
+                  // when display and/or search fields are configured, add the value to the search
+                  // and/or display field otherwise add the value to the search and display field
+                  if (searchFields.contains(propertyName)) {
+                    searchValues.add(value.toString());
+                  }
+                  if (hasDisplayFields) {
+                    if (displayFields.contains(propertyName)) {
+                      displayValues.add(value.toString());
+                    }
+                  }
+                }
+              }
+            });
+        doc.setSearchFields(searchValues.toArray(new String[searchFields.size() + 2]));
+        doc.setDisplayFields(displayValues.toArray(new String[0]));
+        docsBatch.add(doc);
+        if (indexCounter % SOLR_BATCH_SIZE == 0) {
+          updateResponse = solrClient.addBeans(docsBatch);
+          logger.info(
+              "Added {} documents to index, result status: {}",
+              indexCounter,
+              updateResponse.getStatus());
+          docsBatch.clear();
+        }
+      }
+    }
+    if (!docsBatch.isEmpty()) {
+      updateResponse = solrClient.addBeans(docsBatch);
+      logger.info("Added last {} documents to index", docsBatch.size());
+      logger.debug("Update response status: {}", updateResponse.getStatus());
+    }
+
+    updateResponse = this.solrClient.commit();
+    logger.debug("Update response status: {}", updateResponse.getStatus());
+  }
+
+  /**
+   * Clear the index for a layer.
+   *
+   * @param searchLayer the layer id, as created by using {@link #getIndexLayerId(String, String)}
+   * @throws IOException if an I/O error occurs
+   * @throws SolrServerException if a Solr error occurs
+   */
+  public void clearIndexForLayer(String searchLayer) throws IOException, SolrServerException {
+    QueryResponse response =
+        solrClient.query(new SolrQuery("exists(query(" + SEARCH_LAYER + ":" + searchLayer + "))"));
+    if (response.getResults().getNumFound() > 0) {
+      logger.info("Clearing index for searchLayer {}", searchLayer);
+      UpdateResponse updateResponse = solrClient.deleteByQuery(LAYER_NAME_QUERY + searchLayer);
+      logger.debug("Update response status: {}", updateResponse.getStatus());
+      updateResponse = solrClient.commit();
+      logger.debug("Update response status: {}", updateResponse.getStatus());
+    } else {
+      logger.info("No index to clear for layer {}", searchLayer);
+    }
+  }
+
+  /**
+   * Search in the index for a layer.
+   *
+   * @param layer the layer name, as created by using {@link #getIndexLayerId(String, String)}
+   * @param q the query
+   * @param start the start index
+   * @param numResultsToReturn the number of results to return
+   * @return the documents
+   * @throws IOException if an I/O error occurs
+   * @throws SolrServerException if a Solr error occurs
+   */
+  public SolrDocumentList findInIndex(String layer, String q, int start, int numResultsToReturn)
+      throws IOException, SolrServerException {
+    logger.info("Find in index for {}", layer);
+    final SolrQuery query =
+        new SolrQuery(INDEX_SEARCH_FIELD + ":" + q)
+            .setShowDebugInfo(logger.isDebugEnabled())
+            .addField(FID)
+            .addField(SEARCH_LAYER)
+            .addField(INDEX_DISPLAY_FIELD)
+            .addField(INDEX_GEOM_FIELD)
+            .addFilterQuery(LAYER_NAME_QUERY + layer)
+            // cannot sort on multivalued field .setSort(FID, SolrQuery.ORDER.asc)
+            .setRows(numResultsToReturn)
+            .setStart(start * numResultsToReturn);
+    query.set("q.op", "AND");
+    logger.debug("Solr query: {}", query);
+
+    final QueryResponse response = solrClient.query(query);
+    logger.debug("response: {}", response);
+    final SolrDocumentList documents = response.getResults();
+
+    logger.debug("Found {} documents", documents.getNumFound());
+    return documents;
+  }
+
+  /**
+   * Programmatically create the schema if it does not exist. Only checks for the existence of the
+   * search layer {@link Constants#SEARCH_LAYER}.
+   *
+   * @throws SolrServerException if a Solr error occurs
+   * @throws IOException if an I/O error occurs
+   */
+  private void createSchemaIfNotExists() throws SolrServerException, IOException {
+    SchemaRequest.Field fieldCheck = new SchemaRequest.Field(SEARCH_LAYER);
+    boolean schemaExists = true;
+    try {
+      SchemaResponse.FieldResponse isField = fieldCheck.process(solrClient);
+      logger.debug("Field type {} exists", isField.getField());
+    } catch (Exception e) {
+      logger.debug(e.getLocalizedMessage());
+      logger.info("Field type {} does not exist, creating it", SEARCH_LAYER);
+      schemaExists = false;
+    }
+
+    if (schemaExists) {
+      return;
+    }
+
+    logger.info("Creating Solr field type {}", SEARCH_LAYER);
+    SchemaRequest.AddField schemaRequest =
+        new SchemaRequest.AddField(
+            Map.of(
+                "name", SEARCH_LAYER,
+                "type", "string",
+                "indexed", true,
+                "stored", true,
+                "multiValued", false));
+    schemaRequest.process(solrClient);
+
+    logger.info("Creating Solr field type {}", INDEX_GEOM_FIELD);
+    // TODO this should be a spatial field type using ("type", "location_rpt") but that requires
+    // some more work
+    SchemaRequest.AddField schemaRequestGeom =
+        new SchemaRequest.AddField(
+            Map.of(
+                "name", INDEX_GEOM_FIELD,
+                "type", "string",
+                "indexed", true,
+                "stored", true,
+                "multiValued", false));
+    schemaRequestGeom.process(solrClient);
+  }
+
+  /**
+   * Close the Solr client.
+   *
+   * @throws IOException if an I/O error occurs
+   */
+  @Override
+  public void close() throws IOException {
+    this.solrClient.close();
+  }
+}

--- a/src/main/java/nl/b3p/tailormap/api/util/Constants.java
+++ b/src/main/java/nl/b3p/tailormap/api/util/Constants.java
@@ -12,4 +12,10 @@ public interface Constants {
   String NAME_REGEX = "^[a-zA-Z0-9-_]+";
   String NAME_REGEX_INVALID_MESSAGE =
       "name must consist of alphanumeric characters, underscore or -";
+
+  String SEARCH_LAYER = "searchLayer";
+  String LAYER_NAME_QUERY = SEARCH_LAYER + ":";
+  String INDEX_SEARCH_FIELD = "searchFields";
+  String INDEX_DISPLAY_FIELD = "displayFields";
+  String INDEX_GEOM_FIELD = "geometry";
 }

--- a/src/main/java/nl/b3p/tailormap/api/util/Constants.java
+++ b/src/main/java/nl/b3p/tailormap/api/util/Constants.java
@@ -6,15 +6,14 @@
 package nl.b3p.tailormap.api.util;
 
 public interface Constants {
-  String FID = "__fid";
   int DEFAULT_MAX_FEATURES = 10;
-
+  String FID = "__fid";
+  String ID = "id";
   String NAME_REGEX = "^[a-zA-Z0-9-_]+";
   String NAME_REGEX_INVALID_MESSAGE =
       "name must consist of alphanumeric characters, underscore or -";
-
+  String SEARCH_ID_FIELD = ID;
   String SEARCH_LAYER = "searchLayer";
-  String LAYER_NAME_QUERY = SEARCH_LAYER + ":";
   String INDEX_SEARCH_FIELD = "searchFields";
   String INDEX_DISPLAY_FIELD = "displayFields";
   String INDEX_GEOM_FIELD = "geometry";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,6 +41,10 @@ tailormap-api.oidc.client-secret=${OIDC_CLIENT_SECRET:#{null}}
 tailormap-api.oidc.user-name-attribute=${OIDC_CLIENT_USER_NAME_ATTRIBUTE:#{null}}
 tailormap-api.oidc.show-for-viewer=${OIDC_SHOW_FOR_VIEWER:false}
 
+# note trailing slash on url
+tailormap-api.solr-url=${SOLR_URL:'#{"http://solr:8983/solr/"}'}
+tailormap-api.solr-core-name=${SOLR_CORE_NAME:tailormap}
+
 # in the tailormap-viewer Docker Compose stack this is changed to 0.0.0.0
 server.address=localhost
 server.http2.enabled=true

--- a/src/main/resources/db/migration/V7__indexing_metadata_entity.sql
+++ b/src/main/resources/db/migration/V7__indexing_metadata_entity.sql
@@ -1,0 +1,10 @@
+create table search_index
+(
+    id                         bigserial                    not null primary key,
+    feature_type_id            bigint,
+    last_indexed               timestamp(6) with time zone,
+    status                     varchar(8) default 'INITIAL' not null check (status in ('INITIAL', 'INDEXING', 'INDEXED', 'ERROR')),
+    comment                    text,
+    search_fields_used         jsonb,
+    search_display_fields_used jsonb
+);

--- a/src/main/resources/openapi/persistence-schemas.yaml
+++ b/src/main/resources/openapi/persistence-schemas.yaml
@@ -354,6 +354,8 @@ components:
           type: boolean
         featureType:
           $ref: '#/components/schemas/FeatureTypeRef'
+        searchIndex:
+          $ref: '#/components/schemas/SearchIndexRef'
         attribution:
           description: 'Attribution to show for this layer.'
           nullable: true
@@ -366,6 +368,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AuthorizationRule'
+
+    SearchIndexRef:
+      description: Reference (by id) to a search index.
+      required:
+        - SearchIndexId
+      properties:
+        searchIndexId:
+          type: integer
+          format: int64
+          nullable: false
+          uniqueItems: true
 
     FeatureTypeRef:
       required: [featureSourceId, featureTypeName]

--- a/src/main/resources/openapi/persistence-schemas.yaml
+++ b/src/main/resources/openapi/persistence-schemas.yaml
@@ -265,6 +265,18 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/AttributeSettings'
+        searchFields:
+          description: List of attribute names that should be used to build the search index.
+          type: array
+          items:
+            type: string
+        searchDisplayFields:
+          description: List of attribute names that should be shown in the search results, when `null` searchFields is used.
+          type: array
+          nullable: true
+          items:
+            type: string
+
 
     AttributeSettings:
       properties:

--- a/src/main/resources/openapi/viewer-api.yaml
+++ b/src/main/resources/openapi/viewer-api.yaml
@@ -264,6 +264,60 @@ components:
         filterApplied: false
         values: [ "value 1", "value 2" ]
 
+    SearchResponse:
+      description: 'A -possibly empty- list of search documents that fulfill the requested conditions and some metadata.'
+      type: object
+      properties:
+        start:
+          description: 'requested start point, this will allow the client to request the next or previous page by adding or removing 1 or more. See also https://solr.apache.org/guide/solr/latest/query-guide/common-query-parameters.html#start-parameter'
+          type: integer
+          format: int64
+          nullable: true
+          minimum: 0
+        total:
+          description: 'the total number of available search documents, could be an estimated value.'
+          type: integer
+          format: int64
+          nullable: false
+        maxScore:
+          description: 'the maximum score of the search documents. Commonly `null` for wildcard searches as these are filters and don''t score.'
+          type: number
+          format: float
+          nullable: true
+        documents:
+          description: 'list of search documents. When the pagenumber*pagesize exceeds the number of documents this list will be empty'
+          type: array
+          minLength: 0
+          items:
+            $ref: '#/components/schemas/SearchDocument'
+      example: { "total": 2,
+                 "start": 10,
+                 "maxScore": null,
+                 "documents": [ { "fid": "fid1","geometry": "POINT(1 2)","displayValues": [ "value 1","value 2" ] } ] }
+
+    SearchDocument:
+      description: 'A search result document'
+      type: object
+      properties:
+        fid:
+          description: 'The unique identifier of the feature, also the primary key in the underlying data source'
+          type: string
+          nullable: false
+        geometry:
+          description: 'The geometry of the feature (WKT'
+          type: string
+          nullable: true
+        displayValues:
+          description: 'The values from the index to display in the search result'
+          type: array
+          nullable: true
+          items:
+            type: string
+      example: { "fid": "fid1",
+                 "geometry": "POINT(1 2)",
+                 "displayValues": [ "value 1", "value 2" ] }
+
+
 paths:
   /unauthorized:
     get:
@@ -1200,6 +1254,76 @@ paths:
                 $ref: './status-responses.yaml#/components/schemas/RedirectResponse'
         '500':
           description: 'Internal server error'
+          content:
+            application/json:
+              schema:
+                $ref: './status-responses.yaml#/components/schemas/ErrorResponse'
+
+
+  /{viewerKind}/{viewerName}/layer/{appLayerId}/search:
+    summary: 'Use this endpoint to search for features using external indexes (eg. Solr).'
+    parameters:
+      - in: path
+        name: viewerKind
+        required: true
+        schema:
+          type: string
+          enum:
+            - app
+            - service
+      - description: 'viewer name'
+        in: path
+        name: viewerName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: appLayerId
+        required: true
+        schema:
+          type: string
+      - description: '(Solr) search term'
+        in: query
+        name: q
+        required: true
+        schema:
+          type: string
+      - description: 'start index for the search results, default is 0. Use this to paginate the results.'
+        in: query
+        name: start
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+    get:
+      operationId: 'search'
+      description: 'retrieve a limited list of search responses that fulfill the requested conditions (parameters).'
+      security:
+        - formAuth: [ ]
+      responses:
+        '200':
+          description: 'OK'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+        '204':
+          description: 'No content. The search did not return any results. This could be because the search term was too specific and no results were found or there is no search index.'
+        '400':
+          description: 'Bad Request. May be returned for some combination of parameters that can not be processed or are incomplete.'
+          content:
+            application/json:
+              schema:
+                $ref: './status-responses.yaml#/components/schemas/ErrorResponse'
+        '401':
+          description: 'Unauthorized'
+          content:
+            application/json:
+              schema:
+                $ref: './status-responses.yaml#/components/schemas/RedirectResponse'
+        '500':
+          description: 'Internal server error. Something went wrong while processing the search request, maybe search index is down.'
           content:
             application/json:
               schema:

--- a/src/test/java/nl/b3p/tailormap/api/controller/SearchControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/SearchControllerIntegrationTest.java
@@ -142,7 +142,7 @@ class SearchControllerIntegrationTest implements Constants {
                 .accept(MediaType.APPLICATION_JSON)
                 .with(setServletPath(url))
                 .param("q", "bestaan*"))
-        .andExpect(status().isNoContent());
+        .andExpect(status().isNotFound());
   }
 
   @Test
@@ -177,7 +177,7 @@ class SearchControllerIntegrationTest implements Constants {
                 .param("q", "bestaan*"))
         .andExpect(status().isNotFound())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.message").value("Layer does not have feature type"));
+        .andExpect(jsonPath("$.message").value("Layer 'BGT' does not have a search index"));
   }
 
   @Test

--- a/src/test/java/nl/b3p/tailormap/api/controller/SearchControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/SearchControllerIntegrationTest.java
@@ -56,8 +56,7 @@ class SearchControllerIntegrationTest implements Constants {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.start").value(0))
-        .andExpect(
-            jsonPath("$.total").value((both(greaterThan(3660)).and(lessThanOrEqualTo(3665)))))
+        .andExpect(jsonPath("$.total").value(both(greaterThan(3660)).and(lessThanOrEqualTo(3665))))
         .andExpect(jsonPath("$.documents").isArray())
         .andExpect(jsonPath("$.documents.length()").value(10))
         .andExpect(jsonPath("$.documents[0].fid").isString())
@@ -86,8 +85,7 @@ class SearchControllerIntegrationTest implements Constants {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.start").value(0))
-        .andExpect(
-            jsonPath("$.total").value((both(greaterThan(3550)).and(lessThanOrEqualTo(3554)))))
+        .andExpect(jsonPath("$.total").value(both(greaterThan(3550)).and(lessThanOrEqualTo(3554))))
         .andExpect(jsonPath("$.documents").isArray())
         .andExpect(jsonPath("$.documents.length()").value(10))
         .andExpect(jsonPath("$.documents[0].fid").isString())
@@ -117,8 +115,7 @@ class SearchControllerIntegrationTest implements Constants {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.start").value(10))
         .andExpect(
-            jsonPath("$.total")
-                .value((both(greaterThanOrEqualTo(100)).and(lessThanOrEqualTo(110)))))
+            jsonPath("$.total").value(both(greaterThanOrEqualTo(100)).and(lessThanOrEqualTo(110))))
         // .andExpect(jsonPath("$.maxScore").isNumber())
         // .andExpect(jsonPath("$.maxScore").value(closeTo(1.0, 0.1)))
         .andExpect(jsonPath("$.maxScore").isEmpty())

--- a/src/test/java/nl/b3p/tailormap/api/controller/SearchControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/SearchControllerIntegrationTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.controller;
+
+import static nl.b3p.tailormap.api.TestRequestProcessor.setServletPath;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import nl.b3p.tailormap.api.annotation.PostgresIntegrationTest;
+import nl.b3p.tailormap.api.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junitpioneer.jupiter.Stopwatch;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@PostgresIntegrationTest
+@Execution(ExecutionMode.CONCURRENT)
+@Stopwatch
+class SearchControllerIntegrationTest implements Constants {
+  @Value("${tailormap-api.base-path}")
+  private String apiBasePath;
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void searchPostgis() throws Exception {
+    final String url =
+        apiBasePath
+            + "/app/default/layer/lyr:snapshot-geoserver:postgis:begroeidterreindeel/search";
+
+    mockMvc
+        .perform(
+            get(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(setServletPath(url))
+                .param("q", "*")
+                .param("start", "0"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.start").value(0))
+        .andExpect(
+            jsonPath("$.total").value((both(greaterThan(3660)).and(lessThanOrEqualTo(3665)))))
+        .andExpect(jsonPath("$.documents").isArray())
+        .andExpect(jsonPath("$.documents.length()").value(10))
+        .andExpect(jsonPath("$.documents[0].fid").isString())
+        .andExpect(jsonPath("$.documents[0].fid").value(not(contains("wegdeel"))))
+        .andExpect(jsonPath("$.documents[0].displayValues").isArray())
+        .andExpect(jsonPath("$.documents[0]." + INDEX_GEOM_FIELD).isString())
+        // wildcard search == filter, so maxScore is not set
+        // .andExpect(jsonPath("$.maxScore").value(closeTo(1.0, 0.001)))
+        .andExpect(jsonPath("$.maxScore").isEmpty());
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void searchPostgisGroen() throws Exception {
+    final String url =
+        apiBasePath
+            + "/app/default/layer/lyr:snapshot-geoserver:postgis:begroeidterreindeel/search";
+
+    mockMvc
+        .perform(
+            get(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(setServletPath(url))
+                .param("q", "groen*")
+                .param("start", "0"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.start").value(0))
+        .andExpect(
+            jsonPath("$.total").value((both(greaterThan(3550)).and(lessThanOrEqualTo(3554)))))
+        .andExpect(jsonPath("$.documents").isArray())
+        .andExpect(jsonPath("$.documents.length()").value(10))
+        .andExpect(jsonPath("$.documents[0].fid").isString())
+        .andExpect(jsonPath("$.documents[0].fid").value(not(contains("wegdeel"))))
+        .andExpect(jsonPath("$.documents[0].displayValues").isArray())
+        .andExpect(jsonPath("$.documents[0]." + INDEX_GEOM_FIELD).isString())
+        // wildcard search == filter, so maxScore is not set
+        .andExpect(jsonPath("$.maxScore").isEmpty())
+    // .andExpect(jsonPath("$.maxScore").value(closeTo(1.0, 0.1)))
+    ;
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void searchSQLServerStartAtItem10() throws Exception {
+    final String url =
+        apiBasePath + "/app/default/layer/lyr:snapshot-geoserver:sqlserver:wegdeel/search";
+
+    mockMvc
+        .perform(
+            get(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(setServletPath(url))
+                .param("q", "verhard~")
+                .param("start", "10"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.start").value(10))
+        .andExpect(
+            jsonPath("$.total")
+                .value((both(greaterThanOrEqualTo(100)).and(lessThanOrEqualTo(110)))))
+        // .andExpect(jsonPath("$.maxScore").isNumber())
+        // .andExpect(jsonPath("$.maxScore").value(closeTo(1.0, 0.1)))
+        .andExpect(jsonPath("$.maxScore").isEmpty())
+        .andExpect(jsonPath("$.documents").isArray())
+        .andExpect(jsonPath("$.documents.length()").value(10))
+        .andExpect(jsonPath("$.documents[0].fid").isString())
+        .andExpect(jsonPath("$.documents[0].fid").value(not(contains("begroeidterreindeel"))))
+        .andExpect(jsonPath("$.documents[0].displayValues").isArray())
+        .andExpect(jsonPath("$.documents[0]." + INDEX_GEOM_FIELD).isString());
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void searchOracleLayerWithoutIndex() throws Exception {
+    final String url =
+        apiBasePath + "/app/default/layer/lyr:snapshot-geoserver:oracle:WATERDEEL/search";
+
+    mockMvc
+        .perform(
+            get(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(setServletPath(url))
+                .param("q", "bestaan*"))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void testLayerDoesNotExist() throws Exception {
+    final String url =
+        apiBasePath + "/app/default/layer/lyr:snapshot-geoserver:doesnotexist/search";
+
+    mockMvc
+        .perform(
+            get(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(setServletPath(url))
+                .param("q", "bestaan*"))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(
+            jsonPath("$.message")
+                .value("Application layer with id lyr:snapshot-geoserver:doesnotexist not found"));
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void testLayerWithoutFeatureType() throws Exception {
+    final String url = apiBasePath + "/app/default/layer/lyr:snapshot-geoserver:BGT/search";
+
+    mockMvc
+        .perform(
+            get(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(setServletPath(url))
+                .param("q", "bestaan*"))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.message").value("Layer does not have feature type"));
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void testBadRequestQuery() throws Exception {
+    final String url =
+        apiBasePath
+            + "/app/default/layer/lyr:snapshot-geoserver:postgis:begroeidterreindeel/search";
+
+    mockMvc
+        .perform(
+            get(url)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(setServletPath(url))
+                .param("q", "bestaan*")
+                .param("start", "-1"))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.message").value("Error while searching with given query"));
+  }
+}

--- a/src/test/java/nl/b3p/tailormap/api/controller/ViewerControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/ViewerControllerIntegrationTest.java
@@ -167,7 +167,7 @@ class ViewerControllerIntegrationTest {
             // Application layer description
             jsonPath(
                     "$.appLayers[?(@.id === 'lyr:snapshot-geoserver:postgis:begroeidterreindeel')].description")
-                .value(contains(startsWith("This layer shows data from http://www.postgis.net"))));
+                .value(contains(startsWith("This layer shows data from https://www.postgis.net"))));
   }
 
   @Test

--- a/src/test/java/nl/b3p/tailormap/api/controller/admin/SolrAdminControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/admin/SolrAdminControllerIntegrationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.tailormap.api.controller.admin;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import nl.b3p.tailormap.api.annotation.PostgresIntegrationTest;
+import nl.b3p.tailormap.api.persistence.Group;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junitpioneer.jupiter.Stopwatch;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@AutoConfigureMockMvc
+@Stopwatch
+@PostgresIntegrationTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SolrAdminControllerIntegrationTest {
+  @Autowired private WebApplicationContext context;
+  private MockMvc mockMvc;
+
+  @Value("${tailormap-api.admin.base-path}")
+  private String adminBasePath;
+
+  @BeforeAll
+  void initialize() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+  }
+
+  @Test
+  @WithMockUser(
+      username = "tm-admin",
+      authorities = {Group.ADMIN})
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void pingTest() throws Exception {
+    mockMvc
+        .perform(get(adminBasePath + "/index/ping").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.status").value("OK"))
+        .andExpect(jsonPath("$.timeElapsed").isNumber());
+  }
+
+  @Test
+  @WithMockUser(
+      username = "tm-admin",
+      authorities = {Group.ADMIN})
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void deleteNonExistentLayerFromIndex() throws Exception {
+    mockMvc
+        .perform(
+            delete(adminBasePath + "/index/snapshot-geoserver/doesnotexist")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @WithMockUser(
+      username = "tm-admin",
+      authorities = {Group.ADMIN})
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  @Order(1)
+  void addPostgisLayerToIndex() throws Exception {
+    mockMvc
+        .perform(
+            put(adminBasePath + "/index/snapshot-geoserver/postgis:begroeidterreindeel")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isAccepted());
+  }
+
+  @Test
+  @WithMockUser(
+      username = "tm-admin",
+      authorities = {Group.ADMIN})
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  @Order(2)
+  void deletePostgisLayerFromIndex() throws Exception {
+    mockMvc
+        .perform(
+            delete(adminBasePath + "/index/snapshot-geoserver/postgis:begroeidterreindeel")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @WithMockUser(
+      username = "tm-admin",
+      authorities = {Group.ADMIN})
+  @Order(1)
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void indexOracleLayerWithoutSearchFields() throws Exception {
+    mockMvc
+        .perform(
+            put(adminBasePath + "/index/snapshot-geoserver/oracle:WATERDEEL")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isInternalServerError())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(
+            jsonPath("$.message").value(startsWith("No search fields configured for layer")));
+  }
+
+  @Test
+  @WithMockUser(
+      username = "tm-admin",
+      authorities = {Group.ADMIN})
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  @Order(2)
+  void deleteOracleLayerFromIndex() throws Exception {
+    mockMvc
+        .perform(
+            delete(adminBasePath + "/index/snapshot-geoserver/oracle:WATERDEEL")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+  }
+}

--- a/src/test/java/nl/b3p/tailormap/api/controller/admin/SolrAdminControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/admin/SolrAdminControllerIntegrationTest.java
@@ -5,7 +5,6 @@
  */
 package nl.b3p.tailormap.api.controller.admin;
 
-import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -67,12 +66,12 @@ class SolrAdminControllerIntegrationTest {
       username = "tm-admin",
       authorities = {Group.ADMIN})
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  void deleteNonExistentLayerFromIndex() throws Exception {
+  void deleteNonExistentIndex() throws Exception {
     mockMvc
         .perform(
-            delete(adminBasePath + "/index/snapshot-geoserver/doesnotexist")
+            delete(adminBasePath + "/index/snapshot-geoserver/1000")
                 .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNoContent());
+        .andExpect(status().isNotFound());
   }
 
   @Test
@@ -80,11 +79,11 @@ class SolrAdminControllerIntegrationTest {
       username = "tm-admin",
       authorities = {Group.ADMIN})
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  @Order(2)
-  void addPostgisLayerToIndex() throws Exception {
+  @Order(1)
+  void refreshIndex1() throws Exception {
     mockMvc
         .perform(
-            put(adminBasePath + "/index/snapshot-geoserver/postgis:begroeidterreindeel")
+            put(adminBasePath + "/index/1")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isAccepted());
@@ -95,13 +94,23 @@ class SolrAdminControllerIntegrationTest {
       username = "tm-admin",
       authorities = {Group.ADMIN})
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  @Order(1)
-  void deletePostgisLayerFromIndex() throws Exception {
+  @Order(2)
+  void clearIndex1() throws Exception {
     mockMvc
-        .perform(
-            delete(adminBasePath + "/index/snapshot-geoserver/postgis:begroeidterreindeel")
-                .accept(MediaType.APPLICATION_JSON))
+        .perform(delete(adminBasePath + "/index/1").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @WithMockUser(
+      username = "tm-admin",
+      authorities = {Group.ADMIN})
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  @Order(3)
+  void recreateIndex1() throws Exception {
+    mockMvc
+        .perform(put(adminBasePath + "/index/1").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
   }
 
   @Test
@@ -110,29 +119,12 @@ class SolrAdminControllerIntegrationTest {
       authorities = {Group.ADMIN})
   @Order(1)
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  void indexOracleLayerWithoutSearchFields() throws Exception {
+  void indexWithoutSearchIndexConfigured() throws Exception {
     mockMvc
         .perform(
-            put(adminBasePath + "/index/snapshot-geoserver/oracle:WATERDEEL")
+            put(adminBasePath + "/index/100")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isInternalServerError())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(
-            jsonPath("$.message").value(startsWith("No search fields configured for layer")));
-  }
-
-  @Test
-  @WithMockUser(
-      username = "tm-admin",
-      authorities = {Group.ADMIN})
-  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  @Order(2)
-  void deleteOracleLayerFromIndex() throws Exception {
-    mockMvc
-        .perform(
-            delete(adminBasePath + "/index/snapshot-geoserver/oracle:WATERDEEL")
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNoContent());
+        .andExpect(status().isNotFound());
   }
 }

--- a/src/test/java/nl/b3p/tailormap/api/controller/admin/SolrAdminControllerIntegrationTest.java
+++ b/src/test/java/nl/b3p/tailormap/api/controller/admin/SolrAdminControllerIntegrationTest.java
@@ -80,7 +80,7 @@ class SolrAdminControllerIntegrationTest {
       username = "tm-admin",
       authorities = {Group.ADMIN})
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  @Order(1)
+  @Order(2)
   void addPostgisLayerToIndex() throws Exception {
     mockMvc
         .perform(
@@ -95,7 +95,7 @@ class SolrAdminControllerIntegrationTest {
       username = "tm-admin",
       authorities = {Group.ADMIN})
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  @Order(2)
+  @Order(1)
   void deletePostgisLayerFromIndex() throws Exception {
     mockMvc
         .perform(

--- a/src/test/resources/application-postgresql.properties
+++ b/src/test/resources/application-postgresql.properties
@@ -8,6 +8,9 @@ tailormap-api.management.hashed-password=#{null}
 
 tailormap-api.pageSize=10
 
+# note trailing slash on url
+tailormap-api.solr-url=http://localhost:8983/solr/
+
 spring.datasource.url=jdbc:postgresql:tailormap
 spring.datasource.username=tailormap
 spring.datasource.password=tailormap


### PR DESCRIPTION
- [x] [HTM-1064] Update CI compose stack with preconfigured Solr
- [x] [HTM-1066] Spring data REST API to store search fields
- [x] [HTM-1067] Manual create/refresh and delete of a specified Solr index
- [x] [HTM-1074] Add Solr prometheus-exporter to CI stack (related https://github.com/B3Partners/tailormap-viewer/pull/571 and https://github.com/B3Partners/containers/pull/504)
- [x] [HTM-1065] Viewer API + implementation
- [x] documentation below

related: https://github.com/B3Partners/tailormap-viewer/pull/571

# Solr indexing

All Solr logic is implemented in the `solr` package. There are two main classes in the package: `SolrHelper` and `FeatureIndexingDocument`.
The `SolrHelper` class is responsible for interacting with the Solr service, the `FeatureIndexingDocument` class is a POJO that models the mapping from a Feature to a Solr document.

## Indexing

The `admin/index` (GET) method of the `SolrAdminController` class is used to check if the Solr service is up and running using a ping.
The `admin/index` (PUT) method of the `SolrAdminController` class is used to index the feature type associated with a layer in the catalog.
The `admin/index` (DELETE) method of the `SolrAdminController` class is used to delete the index of the feature type associated with a layer in the catalog.

The `SolrAdminController` class will call the `SolrHelper` class for any interaction after validating the request.

### Persistence
A simple metadata class is available that stores information about created indexes, this way we also get a before/after when featuretype settings (that has a list of fields to use for an index) changes

### Indexing document

The `SolrHelper` class is responsible for indexing documents using the `FeatureDocument`. Upon first use the `SolrHelper` will create the necessary fields in the Solr index. The `FeatureDocument` object has the following fields:

- `fid` - the feature id of the feature that the document is associated with, mapped to the `id` in the Solr index
- `searchLayer` - the layer that the feature is associated with, this is a composed value of the service name and the layer name, this is used to filter the search results for a layer so we can get by with a single index for all layers
- `geometry` - the simplified geometry of the feature that the document is associated with (not used in the indexing process, not searchable, see https://b3partners.atlassian.net/browse/HTM-1091)
- `searchFields` - the configured attribute values that can be used to search for the document in the index
- `displayFields` - the configured attribute values that can be used to display the document in the search results list (not used in the indexing process)

Example of a Solr indexed document

```json
{
  "id": "begroeidterreindeel.000f22d5ea3eace21bd39111a7212bd9",
  "searchLayer": "snapshot-geoserver__postgis__begroeidterreindeel",
  "searchFields": [
    "waardeOnbekend",
    "G0344",
    "groenvoorziening"
  ],
  "displayFields": [
    "waardeOnbekend",
    "groenvoorziening"
  ],
  "geometry": "POLYGON ((133809.608 458811.07, 133810.435 458811.916, 133811.103 458811.219, 133810.341 458810.44, 133809.608 458811.07))",
  "_version_": 1795414299316846592
}
```

## Searching

Search is done using the `/search` GET method of the application as documented in the `viewer-api.yml` through the `SearchController` class.
Based on the given application, layer and search parameters, the `SearchController` class will call the `SolrHelper` class to search for documents in the index after validating the request.

### Search results

The `viewer-api.yml` document specifies the search results format. A search will return a (possibly empty) list
of `SearchDocument` objects (as `documents` array) and some metadata.
The metadata contains the following fields:

- `start` - the index of the first search result in the list of search results
- `total` - the total number of search results
- `time` - the time taken to search for the documents
- `maxScore` - the maximum score of the search results

The `SearchDocument` object contains the following fields:

- `fid` - the feature id of the feature that the search result is associated with and which can used to retrieve the feature from the database
- `geometry` - the (simplified) geometry of the feature that the search result is associated with and that can be used to highlight the feature on the map
- `displayValues` - the configured attribute values that can be used to display the search result in the search results list




[HTM-1064]: https://b3partners.atlassian.net/browse/HTM-1064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HTM-1066]: https://b3partners.atlassian.net/browse/HTM-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HTM-1067]: https://b3partners.atlassian.net/browse/HTM-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HTM-1074]: https://b3partners.atlassian.net/browse/HTM-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HTM-1065]: https://b3partners.atlassian.net/browse/HTM-1065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ