### PR TITLE
HTM-1032: Disable CSRF filter for FeaturesController 

### DIFF
--- a/src/main/java/nl/b3p/tailormap/api/security/ApiSecurityConfiguration.java
+++ b/src/main/java/nl/b3p/tailormap/api/security/ApiSecurityConfiguration.java
@@ -82,7 +82,10 @@ public class ApiSecurityConfiguration {
       http.csrf(
           csrf ->
               csrf.csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
-                  .csrfTokenRepository(csrfTokenRepository));
+                  .csrfTokenRepository(csrfTokenRepository)
+                  // This uses POST for large filter in body, but is safe (read-only)
+                  .ignoringRequestMatchers(
+                      apiBasePath + "/{viewerKind}/{viewerName}/layer/{appLayerId}/features"));
       http.addFilterAfter(new CsrfCookieFilter(), BasicAuthenticationFilter.class);
     }
 


### PR DESCRIPTION
The FeaturesControler only uses POST for an idempotent request because the filter can possibly be too large for a URL query parameter so with a POST request the filter can be sent in the request body. Disable CSRF protection for this controller so feature info requests etc. can be used when Tailormap is embedded an iframe when the XSRF token can't be read from the 3rd party cookie (even with SameSite=None, with strict browser protection settings this is still blocked by some current browsers which have those by default).