### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ SPDX-License-Identifier: MIT
         <!-- <snakeyaml.version>2.2</snakeyaml.version>-->
         <spring-security.version>6.2.3</spring-security.version>
         <spring-data-bom.version>2023.1.4</spring-data-bom.version>
-        <spring-hateoas.version>2.2.1</spring-hateoas.version>
+        <spring-hateoas.version>2.2.2</spring-hateoas.version>
         <okhttp.version>5.0.0-alpha.12</okhttp.version>
         <logback.version>1.5.3</logback.version>
         <!-- <slf4j.version>2.0.12</slf4j.version>-->

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ SPDX-License-Identifier: MIT
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <jackson-bom.version>2.17.0</jackson-bom.version>
         <!-- <json-path.version>2.9.0</json-path.version>-->
-        <micrometer.version>1.12.4</micrometer.version>
+        <micrometer.version>1.12.5</micrometer.version>
         <hibernate.version>6.4.4.Final</hibernate.version>
         <junit-jupiter.version>5.10.2</junit-jupiter.version>
         <mssql-jdbc.version>12.6.1.jre11</mssql-jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
         <postgresql.version>42.7.3</postgresql.version>
         <!-- <snakeyaml.version>2.2</snakeyaml.version>-->
         <spring-security.version>6.2.3</spring-security.version>
-        <spring-data-bom.version>2023.1.4</spring-data-bom.version>
+        <spring-data-bom.version>2023.1.5</spring-data-bom.version>
         <spring-hateoas.version>2.2.2</spring-hateoas.version>
         <okhttp.version>5.0.0-alpha.12</okhttp.version>
         <logback.version>1.5.3</logback.version>


### PR DESCRIPTION
- Bump `micrometer.version` from 1.12.4 to 1.12.5
- Bump `spring-hateoas.version` from 2.2.1 to 2.2.2
- Bump `spring-data-bom.version` from 2023.1.4 to 2023.1.5