### PR TITLE
[HTM-1127] Change XEPDB1 to FREEPDB1 so we can benefit from the Oracle upgrade to 23.4

### DIFF
--- a/build/ci/docker-compose.yml
+++ b/build/ci/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     image: docker.b3p.nl/b3partners/tailormap-data_oracle:snapshot
     environment: # Note Oracle has default maximum password length of 16!
       ORACLE_PASSWORD: ${ORACLE_PASSWORD:-fa6efb5b-075b-4b}
-      # this user is created in XEPDB1, not in XE
+      # this user is created in FREEPDB1, not in XE
       APP_USER: "geodata"
       APP_USER_PASSWORD: ${GEODATA_PASSWORD:-980f1c8A-25933b2}
       GEODATA_PASSWORD: ${GEODATA_PASSWORD:-980f1c8A-25933b2}

--- a/src/main/java/nl/b3p/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/nl/b3p/tailormap/api/configuration/dev/PopulateTestData.java
@@ -595,7 +595,7 @@ public class PopulateTestData {
                     new JDBCConnectionProperties()
                         .dbtype(JDBCConnectionProperties.DbtypeEnum.ORACLE)
                         .host(connectToSpatialDbsAtLocalhost ? "127.0.0.1" : "oracle")
-                        .database("/XEPDB1")
+                        .database("/FREEPDB1")
                         .schema("GEODATA")
                         .additionalProperties(
                             Map.of("connectionOptions", "?oracle.jdbc.J2EE13Compliant=true")))


### PR DESCRIPTION
Note that the existing Oracle container + volume must be dropped/recreated and GeoServer will need an updated database connection, see https://github.com/B3Partners/containers/pull/556

resolves HTM-1127