### PR TITLE
Maven and dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ SPDX-License-Identifier: MIT
         <junit-jupiter.version>5.10.3</junit-jupiter.version>
         <logback.version>1.5.6</logback.version>
         <micrometer.version>1.13.1</micrometer.version>
-        <mssql-jdbc.version>12.6.2.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>12.6.3.jre11</mssql-jdbc.version>
         <okhttp.version>5.0.0-alpha.14</okhttp.version>
         <oracle-database.version>23.4.0.24.05</oracle-database.version>
         <postgresql.version>42.7.3</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -553,7 +553,7 @@ SPDX-License-Identifier: MIT
                 <plugin>
                     <groupId>org.openapitools</groupId>
                     <artifactId>openapi-generator-maven-plugin</artifactId>
-                    <version>7.7.0</version>
+                    <version>7.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.hibernate.orm.tooling</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -553,7 +553,7 @@ SPDX-License-Identifier: MIT
                 <plugin>
                     <groupId>org.openapitools</groupId>
                     <artifactId>openapi-generator-maven-plugin</artifactId>
-                    <version>7.6.0</version>
+                    <version>7.7.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.hibernate.orm.tooling</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@ SPDX-License-Identifier: MIT
         <maven-pmd-plugin.version>3.23.0</maven-pmd-plugin.version>
         <versions-maven-plugin.version>2.17.0</versions-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-        <dependency-check-maven.version>9.2.0</dependency-check-maven.version>
+        <dependency-check-maven.version>10.0.1</dependency-check-maven.version>
         <modernizer-maven-plugin.version>2.9.0</modernizer-maven-plugin.version>
         <maven-fluido-skin.version>2.0.0-M9</maven-fluido-skin.version>
         <swagger-ui.version>5.17.14</swagger-ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ SPDX-License-Identifier: MIT
         to check
         -->
         <commons-lang3.version>3.14.0</commons-lang3.version>
-        <flyway.version>10.15.0</flyway.version>
+        <flyway.version>10.15.2</flyway.version>
         <hibernate.version>6.5.2.Final</hibernate.version>
         <jackson-bom.version>2.17.1</jackson-bom.version>
         <junit-jupiter.version>5.10.3</junit-jupiter.version>


### PR DESCRIPTION
- Bump dependency-check-maven.version from 9.2.0 to 10.0.1
- ~~Bump openapi-generator-maven-plugin from 7.6.0 to 7.7.0~~ reverted
- Bump flyway.version from 10.15.0 to 10.15.2
- Bump mssql-jdbc.version from 12.6.2.jre11 to 12.6.3.jre11